### PR TITLE
Change github action to use main branches if env not set

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           repository: xataio/website
           # TODO: Change branch to "main" once we have a stable release
-          ref: ${{ inputs.branch || 'docs_migration' }}
+          ref: ${{ inputs.branch || 'main' }}
           token: ${{ secrets.GIT_TOKEN }}
 
       - uses: actions/setup-node@v3
@@ -38,8 +38,8 @@ jobs:
             --env MDX_DOCS_BRANCH='${{ github.head_ref || github.ref_name }}' \
             --build-env XATA_PREVIEW=none \
             --env XATA_PREVIEW=none \
-            --build-env XATA_BRANCH=docs_migration \
-            --env XATA_BRANCH=docs_migration \
+            --build-env XATA_BRANCH=main \
+            --env XATA_BRANCH=main \
             > deploy_url.txt
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx


### PR DESCRIPTION
Merge after https://github.com/xataio/mdx-docs merges

@SferaDev double check our search logic works ok with these changes so we don't pollute main search. I think it still does, but I noticed you changed it from appending the branch to the sha so I wanted to make sure.