### PR TITLE
Fix open API reference

### DIFF
--- a/060-Rest-API/030-openapi.mdx
+++ b/060-Rest-API/030-openapi.mdx
@@ -9,11 +9,11 @@ published: true
 
 To provide an easy way to use your favorite tools for exploring the Xata API, you can use the [OpenAPI](https://www.openapis.org/) specification:
 
-[Core API spec](https://xata.io/docs/api/openapi?scope=core)
+[Core API spec](https://xata.io/api/openapi?scope=core)
 
 The base url is `https://api.xata.io` and this give you to access to the core API.
 
-[Workspace API spec](https://xata.io/docs/api/openapi?scope=workspace)
+[Workspace API spec](https://xata.io/api/openapi?scope=workspace)
 
 The base url is `https://{workspaceId}.{regionId}.xata.sh` and this give you access to the workspace API.
 


### PR DESCRIPTION
Because of how the APIs are now generated from root, we needed to move the location of the open API spec. Once https://github.com/xataio/website/pull/497 is merged, this PR should merge to account for the change.
