### PR TITLE
Sync changes after relaunch

### DIFF
--- a/030-Concepts/020-how-it-works.mdx
+++ b/030-Concepts/020-how-it-works.mdx
@@ -50,17 +50,12 @@ A record in Xata can look something like this:
   "name": "John Doe",
   "email": "john@example.com",
   "age": 42,
-  "address": {
-    "street": "123 Main St",
-    "city": "New York"
-  },
+  "address": "123 Main St, New York",
   "labels": ["admin", "user"]
 }
 ```
 
-The above shows a column of type object (`address`) with two sub-keys (`street` and `city`). It also shows a column of type email and an array-like column (`labels` of type `multiple`).
-
-When this data is stored in PostgreSQL and Elasticsearch, the objects are flattened into columns identified by IDs. By using IDs for columns, instead of their user-visible names, we make some migrations simpler and we make it possible, for example, to track a column across branches even if it was renamed.
+The above shows a column of type email and an array-like column (`labels` of type `multiple`). When this data is stored in PostgreSQL and Elasticsearch, columns identified by IDs. By using IDs for columns, instead of their user-visible names, we make some migrations simpler and we make it possible, for example, to track a column across branches even if it was renamed.
 
 As a result, the underlying PostgreSQL table might look something like this:
 
@@ -186,7 +181,7 @@ The `/query` and `/summarize` API endpoints are served from the transactional st
 
 As you can see in the above examples, the filtering syntax is the same across the different types of stores, meaning that it’s easy to move queries from one to another.
 
-While we expect most users to use our high-level SDK clients, which make development easier, the REST API is meant to be also easy to understand and use directly. Because it is using JSON, it is more verbose than SQL, but on the other hand, it makes it easier to use with functionality that doesn’t cleanly map into SQL, like free-text-search, complex aggregations, nested objects, etc.
+While we expect most users to use our high-level SDK clients, which make development easier, the REST API is meant to be also easy to understand and use directly. Because it is using JSON, it is more verbose than SQL, but on the other hand, it makes it easier to use with functionality that doesn’t cleanly map into SQL, like free-text-search, complex aggregations, etc.
 
 At the moment, the Xata service doesn’t offer direct access to the PostgreSQL and Elasticsearch instances using their native protocols. The reasons for this might become more clear after reading the following sections, but in short: it allows us to control the underlying schema and what type of queries are possible, and therefore we can ultimately offer our users a new and safer developer experience. For the future, we do have plans to offer SQL support while still maintaining the advantages of mediating access to the underlying stores.
 

--- a/030-Concepts/030-data-model.mdx
+++ b/030-Concepts/030-data-model.mdx
@@ -7,7 +7,7 @@ slug: concepts/data-model
 published: true
 ---
 
-Xata has a relational data model, with a strict schema (schemaful) and with support for JSON-like objects. Records are grouped into tables, which are grouped into databases. Xata supports rich column types and relations between tables can be represented via link columns, which are similar to foreign keys.
+Xata has a relational data model, with a strict schema. Records are grouped into tables, which are grouped into databases. Xata supports rich column types and relations between tables can be represented via link columns, which are similar to foreign keys.
 
 Internally, we are storing the data both in a transactional database (OLTP) as well as in a search/analytics engine (OLAP). This is done transparently for you and the different stores are exposed via the same API. You can read more about how Xata works behind the scenes on the [How it Works](/docs/concepts/how-it-works) page.
 
@@ -26,10 +26,7 @@ The following is an example of a record that you can store natively in Xata:
   "name": "John Doe",
   "email": "john@example.com",
   "age": 42,
-  "address": {
-    "street": "123 Main St",
-    "city": "New York"
-  },
+  "address": "123 Main St, New York",
   "labels": ["admin", "user"]
 }
 ```
@@ -56,17 +53,7 @@ The keys in the JSON are the column names. The values are the data. The corespon
         },
         {
           "name": "address",
-          "type": "object",
-          "columns": [
-            {
-              "name": "street",
-              "type": "string"
-            },
-            {
-              "name": "city",
-              "type": "string"
-            }
-          ]
+          "type": "string"
         },
         {
           "name": "labels",
@@ -259,42 +246,6 @@ produced by any other machine learning model. Once you store the embeddings, you
 </Alert>
 
 The `object` type represents a group of columns. Objects can also be nested multiple times by adding a column of type `object` inside the object. Set `unique` to make sure the objects you insert are unique.
-
-Example definition:
-
-```json
-{
-  "name": "address",
-  "type": "object",
-  "columns": [
-    {
-      "name": "street",
-      "type": "string"
-    },
-    {
-      "name": "city",
-      "type": "string"
-    }
-  ]
-}
-```
-
-To insert a value of type `object`, simply use a JSON map:
-
-```json
-{
-  "address": {
-    "street": "123 Main St",
-    "city": "New York"
-  }
-}
-```
-
-While the API supports the object type, the Web UI and CLI do not expose it as an option yet. There is still work in progress.
-
-In the Web UI, object fields can be created implicitly by creating columns with dotted names. For example columns "user.id" and "user.name" will result in a column "user" of type "object" with the fields "id" and "name" in it, while "user.details.address" will create a nested object "details" within the object "user".
-
-At the moment Xata does not provide automatic schema expansion from JSON objects. The object's structure must be explicitly defined with matching columns in the schema. In case an incoming record contains a JSON object that does not comply with the defined schema, the record will be rejected. Alternatively, JSON content can be stored in text columns.
 
 ### link
 

--- a/030-Concepts/050-schema.mdx
+++ b/030-Concepts/050-schema.mdx
@@ -50,17 +50,7 @@ Let's look at a JSON representation of a sample Xata schema to understand how it
         },
         {
           "name": "address",
-          "type": "object",
-          "columns": [
-            {
-              "name": "street",
-              "type": "string"
-            },
-            {
-              "name": "zipcode",
-              "type": "int"
-            }
-          ]
+          "type": "string"
         },
         {
           "name": "team",

--- a/040-Typescript-SDK/030-create.mdx
+++ b/040-Typescript-SDK/030-create.mdx
@@ -14,7 +14,7 @@ You can create a record like this:
 ```ts
 const record = await xata.db.Users.create({
   email: 'keanu@example.com',
-  name: 'keanu@example.com'
+  name: 'Keanu Reeves'
 });
 ```
 
@@ -34,11 +34,11 @@ The TypeScript SDK returns the created record. The response looks like this:
 <TabbedCode tabs={['TypeScript', 'JSON']}>
   ```ts
   {
-    "email":"keanu@example.com"
-    "id":"rec_cd8rqcoavc42pi67lgd0"
-    "name":"keanu@example.com"
-    "bio":NULL
-    "address":NULL
+    "email": "keanu@example.com",
+    "id": "rec_cd8rqcoavc42pi67lgd0",
+    "name": "Keanu Reeves",
+    "bio": NULL,
+    "address": NULL,
   }
 ```
 
@@ -68,7 +68,7 @@ If you want to specify your own ID, you can do it like this:
 ```ts
 const record = await xata.db.Users.create("myid", {
   email: "keanu@example.com",
-  name: "keanu@example.com"
+  name: "Keanu Reeves"
 });
 ```
 

--- a/040-Typescript-SDK/040-get.mdx
+++ b/040-Typescript-SDK/040-get.mdx
@@ -167,7 +167,7 @@ For example, if you are only interested in the name and the city of the user, yo
 <TabbedCode tabs={['TypeScript', 'JSON']}>
 ```ts
 const users = await xata.db.Users
-  .select(["name", "address.city"])
+  .select(["name", "city"])
   .getMany();
 ```
 
@@ -175,7 +175,7 @@ const users = await xata.db.Users
 // POST https://tutorial-ng7s8c.us-east-1.xata.sh/db/tutorial:main/tables/Users/query
 
 {
-  "columns": ["name", "address.city"]
+  "columns": ["name", "city"]
 }
 ```
 
@@ -274,7 +274,7 @@ To refer to nested columns, you can use either the dot notation:
 <TabbedCode tabs={['TypeScript', 'JSON']}>
 
 ```ts
-const users = await xata.db.Users.filter({ 'address.zipcode': 12345 }).getMany();
+const users = await xata.db.Users.filter({ 'zipcode': 12345 }).getMany();
 ```
 
 ```jsonc
@@ -282,7 +282,7 @@ const users = await xata.db.Users.filter({ 'address.zipcode': 12345 }).getMany()
 
 {
   "filter": {
-    "address.zipcode": 12345
+    "zipcode": 12345
   }
 }
 ```
@@ -317,7 +317,7 @@ To give a more complex filtering example, consider the following:
 ```ts
 const users = await xata.db.Users
   .filter({
-    "address.zipcode": { $gt: 100 },
+    "zipcode": { $gt: 100 },
     $any: [
       { name: { $contains: "Keanu" } },
       { name: { $contains: "Carrie" } },
@@ -331,7 +331,7 @@ const users = await xata.db.Users
 
 {
   "filter": {
-    "address.zipcode": {
+    "zipcode": {
       "$gt": 100
     },
     "$any": [
@@ -406,7 +406,7 @@ It is also possible to have secondary sort criteria. For example:
 <TabbedCode tabs={['TypeScript', 'JSON']}>
 
 ```ts
-const users = await xata.db.Users.sort('address.city', 'desc').sort('name', 'asc').getMany();
+const users = await xata.db.Users.sort('city', 'desc').sort('name', 'asc').getMany();
 ```
 
 ```jsonc
@@ -415,7 +415,7 @@ const users = await xata.db.Users.sort('address.city', 'desc').sort('name', 'asc
 {
   "sort": [
     {
-      "address.city": "desc"
+      "city": "desc"
     },
     {
       "name": "asc"

--- a/040-Typescript-SDK/050-filtering.mdx
+++ b/040-Typescript-SDK/050-filtering.mdx
@@ -119,7 +119,7 @@ When you include multiple columns within the same filter, they are logically com
 ```ts
 const records = await xata.db.Users.filter({
   name: 'Keanu Reaves',
-  'address.city': 'New York'
+  'city': 'New York'
 }).getMany();
 ```
 
@@ -129,7 +129,7 @@ const records = await xata.db.Users.filter({
 {
   "filter": {
     "name": "Keanu Reaves",
-    "address.city": "New York"
+    "city": "New York"
   }
 }
 ```
@@ -145,7 +145,7 @@ operators:
 const records = await xata.db.Users.filter({
   $any: {
     name: 'Keanu Reaves',
-    'address.city': 'New York'
+    'city': 'New York'
   }
 }).getMany();
 ```
@@ -157,7 +157,7 @@ const records = await xata.db.Users.filter({
   "filter": {
     "$any": {
       "name": "Keanu Reaves",
-      "address.city": "New York"
+      "city": "New York"
     }
   }
 }
@@ -327,7 +327,7 @@ The `$not: { $any: {}}` can be shorted using the `$none` operator:
 const records = await xata.db.Users.filter({
   $none: {
     name: 'Keanu Reave',
-    'address.city': 'New York'
+    'city': 'New York'
   }
 }).getMany();
 ```
@@ -339,7 +339,7 @@ const records = await xata.db.Users.filter({
   "filter": {
     "$none": {
       "name": "Keanu Reave",
-      "address.city": "New York"
+      "city": "New York"
     }
   }
 }


### PR DESCRIPTION
Some of the changes made to docs to highlight the [object deprecation](https://xata.io/docs/concepts/data-model#object) did not make it into the new repo. This PR adds these unsync'ed bits.

### Timing

**Release**:

- [x] When ready
- [ ] Hold for release | Release after: <mm/dd/yy>
