### PR TITLE
Correct typo on 040-namespace-reference.mdx

### DIFF
--- a/050-Python-SDK/040-namespace-reference.mdx
+++ b/050-Python-SDK/040-namespace-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python namespace references
-navTitle: Namespace referneces
+navTitle: Namespace references
 keywords: ['sdk', 'python']
 description: Reference for the namespaces that provide access to the available Xata endpoints for managing databases
 slug: python-sdk/namespace-refernces


### PR DESCRIPTION
Fix minor typo on the python SDK nav

Closes #

## Summary

- Change`referneces` -> `references` in the navTitle

---

### Timing

**Release**:

- [ ] When ready
- [ ] Hold for release | Release after: <mm/dd/yy>
