### PR TITLE
Quote xata.createdAt

### DIFF
--- a/040-Typescript-SDK/050-filtering.mdx
+++ b/040-Typescript-SDK/050-filtering.mdx
@@ -506,10 +506,10 @@ Example with date ranges, using the built-in [Xata timestamp columns](/docs/conc
 const records = await xata.db.Posts.filter({
   $all: [
     {
-      xata.createdAt: { $ge: new Date("2022-10-25T01:00:00Z") },
+      "xata.createdAt": { $ge: new Date("2022-10-25T01:00:00Z") },
     },
     {
-      xata.createdAt: { $lt: new Date("2022-10-25T02:00:00Z") },
+      "xata.createdAt": { $lt: new Date("2022-10-25T02:00:00Z") },
     }
   ],
 }).getMany();


### PR DESCRIPTION
Using `xata.createdAt` in filter context without quotes hits a PARSE_ERROR.

This updates the relevant docs example.

Reported on [Discord](https://discord.com/channels/996791218879086662/996791219348852836/1135793039986659408)