### PR TITLE
Update 050-schema.mdx

### DIFF
--- a/030-Concepts/050-schema.mdx
+++ b/030-Concepts/050-schema.mdx
@@ -65,7 +65,7 @@ Let's look at a JSON representation of a sample Xata schema to understand how it
 }
 ```
 
-### [`tables`](#tables)
+### tables
 
 The `tables` field is an array (a collection) of objects, each representing a table. Every table has a unique `name`, and a set of `columns`. Table names must be case-insensitive unique within a database schema. Each column is described by the following set of fields.
 

--- a/030-Concepts/050-schema.mdx
+++ b/030-Concepts/050-schema.mdx
@@ -65,7 +65,7 @@ Let's look at a JSON representation of a sample Xata schema to understand how it
 }
 ```
 
-### `tables`
+### [`tables`](#tables)
 
 The `tables` field is an array (a collection) of objects, each representing a table. Every table has a unique `name`, and a set of `columns`. Table names must be case-insensitive unique within a database schema. Each column is described by the following set of fields.
 


### PR DESCRIPTION
## Summary

Noticed that clicking "tables" on the right-hand-side nav menu on: https://xata.io/docs/concepts/schema doesn't work quite right because `tables` is formatted to be code.

Attempting a quick-fix.