### PR TITLE
Fix relation query example

### DIFF
--- a/030-Concepts/030-data-model.mdx
+++ b/030-Concepts/030-data-model.mdx
@@ -316,7 +316,6 @@ Also, you can navigate the link in the opposite direction, from the target table
 ```jsonc
 // POST /db/blogs:main/tables/users/query
 {
-  "table": "users",
   "columns": [
     "name",
     {


### PR DESCRIPTION
Removing the table parameter, which causes `"message": "invalid key [table] in request"`.