### PR TITLE
Adjust timeout for preview action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -56,8 +56,9 @@ jobs:
         id: await-vercel
         with:
           deployment-url: steps.get-url.outputs.URL
-          timeout: 1000
+          timeout: 900
           poll-interval: 10
+        timeout-minutes: 15
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Get deployment URL
         id: get-url
         run: |
-          cat deploy_url.txt
           echo "URL=$(cat deploy_url.txt)" >> $GITHUB_OUTPUT
 
       - name: Find Comment

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,6 @@ jobs:
             --env XATA_PREVIEW=none \
             --build-env XATA_BRANCH=main \
             --env XATA_BRANCH=main \
-            --no-wait \
             > deploy_url.txt
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
@@ -51,16 +50,6 @@ jobs:
         run: |
           cat deploy_url.txt
           echo "URL=$(cat deploy_url.txt)" >> $GITHUB_OUTPUT
-
-      - name: Wait for vercel deploy
-        uses: UnlyEd/github-action-await-vercel@v1
-        id: await-vercel
-        with:
-          deployment-url: steps.get-url.outputs.URL
-          timeout: 900
-          poll-interval: 10
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
       - name: Find Comment
         uses: peter-evans/find-comment@v2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Get deployment URL
         id: get-url
         run: |
+          cat deploy_url.txt
           echo "URL=$(cat deploy_url.txt)" >> $GITHUB_OUTPUT
 
       - name: Wait for vercel deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -56,7 +56,7 @@ jobs:
         id: await-vercel
         with:
           deployment-url: steps.get-url.outputs.URL
-          timeout: 240
+          timeout: 1000
           poll-interval: 10
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout website repo
         uses: actions/checkout@v3
@@ -59,7 +59,6 @@ jobs:
           deployment-url: steps.get-url.outputs.URL
           timeout: 900
           poll-interval: 10
-        timeout-minutes: 15
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,6 +40,7 @@ jobs:
             --env XATA_PREVIEW=none \
             --build-env XATA_BRANCH=main \
             --env XATA_BRANCH=main \
+            --no-wait \
             > deploy_url.txt
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,6 +51,16 @@ jobs:
         run: |
           echo "URL=$(cat deploy_url.txt)" >> $GITHUB_OUTPUT
 
+      - name: Wait for vercel deploy
+        uses: UnlyEd/github-action-await-vercel@v1
+        id: await-vercel
+        with:
+          deployment-url: steps.get-url.outputs.URL
+          timeout: 240
+          poll-interval: 10
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Problem:
https://github.com/xataio/mdx-docs/actions/runs/5948723525/job/16133075036?pr=62

I think this is happening because vercel is configured for 2 concurrent builds, so often we're waiting 10mins for this vercel deploy to happen but the github action is configured for 5 mins.



