### PR TITLE
move attachments from sdk folder

### DIFF
--- a/050-Media-management/150-file-attachments.mdx
+++ b/050-Media-management/150-file-attachments.mdx
@@ -133,11 +133,12 @@ const user = await xata.db.Users.update('record_id', { photo: null });
 // or, using the `update` method on the record object:
 
 await user.update({ photo: null });
-```
+
+````
 
 ```python
 record = xata.records().update("Users", "record_id", {"photo": None})
-```
+````
 
 ```jsonc
 // PATCH https://{workspace}.{region}.xata.sh/db/{db}:{branch}/tables/{table}/data/record_id

--- a/050-Media-management/160-image-transformations.mdx
+++ b/050-Media-management/160-image-transformations.mdx
@@ -30,14 +30,14 @@ const record = xata.db.gallery.read('record_id');
 // Get a new url and signedUrl for an image in the "imageColumnName"
 // This will create a square image that is cropped from the top
 const { url, signedUrl } = record.imageColumnName.transform({
-  height: 500,
-  width: 500,
-  format: 'webp',
-  fit: 'cover',
-  gravity: 'top'
+height: 500,
+width: 500,
+format: 'webp',
+fit: 'cover',
+gravity: 'top'
 });
 
-```
+````
 
 ```python
 img = xata.files().transform("https://us-east-1.storage.xata.sh/s38lomas915pn3vetrp1gomd7g", {
@@ -47,7 +47,7 @@ img = xata.files().transform("https://us-east-1.storage.xata.sh/s38lomas915pn3ve
   "fit": "cover",
   "gravity": "top"
 })
-```
+````
 
 ```sh
 curl 'https://es-east-1.storage.xata.sh/transform/height=50,format=webp/s38lomas915pn3vetrp1gomd7g' \
@@ -185,6 +185,7 @@ transformed_image = xata.files().transform("https://us-east-1.storage.xata.sh/s3
   "fit": "contain"
 })
 ```
+
 </TabbedCode>
 
 <TransformImageExample
@@ -210,6 +211,7 @@ transformed_image = xata.files().transform("https://us-east-1.storage.xata.sh/s3
   "fit": "contain"
 })
 ```
+
 </TabbedCode>
 
 <TransformImageExample


### PR DESCRIPTION
Closes #

## Summary

-The SDK folder may get bloated since we have put languages and "How to" content in there. It might increase visibility and make things a bit easier to find if we moved the attachments into a separate section. WDYT? 

### Remaining work

The following work still needs to be completed:

- I think at a later time we should also whittle down the concepts folder and move some docs that are not architecture-related and less general to maybe a "features" folder. 

### Dependencies

- [ ] <Tasks that must be completed before merging this pull request>

---

### Timing

**Release**:

- [ ] When ready
- [ ] Hold for release | Release after: <mm/dd/yy>
