### PR TITLE
Use parameterized queries in SQL examples

### DIFF
--- a/040-SDK/101-get.mdx
+++ b/040-SDK/101-get.mdx
@@ -240,7 +240,8 @@ user = xata.data().query("Users", "myid")
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * from \"Users\" WHERE id='myid';"
+  "statement": "SELECT * from \"Users\" WHERE id=$1;",
+  "params": ["myid"]
 }
 ```
 
@@ -406,7 +407,8 @@ users = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE email='keanu@example.com' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE email=$1 LIMIT 20;",
+  "params": ["keanu@example.com"]
 }
 ```
 
@@ -444,7 +446,8 @@ users = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" LEFT JOIN \"Teams\" ON \"Users\".team=\"Teams\".id WHERE \"Teams\".name='Matrix';"
+  "statement": "SELECT * FROM \"Users\" LEFT JOIN \"Teams\" ON \"Users\".team=\"Teams\".id WHERE \"Teams\".name=$1;",
+  "params": ["Matrix"]
 }
 ```
 

--- a/040-SDK/102-create.mdx
+++ b/040-SDK/102-create.mdx
@@ -40,7 +40,8 @@ record = xata.records().insert("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "INSERT INTO \"Users\" (email,name) VALUES ('keanu@example.com','Keanu Reeves') RETURNING *;"
+  "statement": "INSERT INTO \"Users\" (email,name) VALUES ($1,$2) RETURNING *;",
+  "params": ["keanu@example.com", "Keanu Reeves"]
 }
 ```
 
@@ -137,7 +138,8 @@ record = xata.records().insert_with_id("Users", "myid" {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "INSERT INTO \"Users\" (id,email,name) VALUES ('myid','keanu@example.com','Keanu Reeves') RETURNING *;"
+  "statement": "INSERT INTO \"Users\" (id,email,name) VALUES ($1,$2,$3) RETURNING *;",
+  "params": ["myid", "keanu@example.com", "Keanu Reeves"]
 }
 ```
 
@@ -176,7 +178,8 @@ record = xata.records().insert("Posts", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "INSERT INTO \"Posts\" (title,author) VALUES ('Filming the Matrix','rec_cd8rqcoavc42pi67lgd0') RETURNING *;"
+  "statement": "INSERT INTO \"Posts\" (title,author) VALUES ($1,$2) RETURNING *;",
+  "params": ["Filming the Matrix", "rec_cd8rqcoavc42pi67lgd0"]
 }
 ```
 
@@ -241,7 +244,8 @@ users = xata.records().bulk_insert("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "INSERT INTO \"Users\" (email,name,team) VALUES ('laurence@example.com','Laurence Fishburne','rec_cd8s4kbo8dsvsjilo1ug'),('hugo@example.com','Hugo Weaving','rec_cd8s4kbo8dsvsjilo1ug'),('joe@example.com','Joe Pantoliano','rec_cd8s4kbo8dsvsjilo1ug') RETURNING *;"
+  "statement": "INSERT INTO \"Users\" (email,name,team) VALUES ($1,$2,$3),($4,$5,$6),($7,$8,$9) RETURNING *;",
+  "params": ["laurence@example.com", "Laurence Fishburne", "rec_cd8s4kbo8dsvsjilo1ug", "hugo@example.com", "Hugo Weaving", "rec_cd8s4kbo8dsvsjilo1ug", "joe@example.com", "Joe Pantoliano", "rec_cd8s4kbo8dsvsjilo1ug"]
 }
 ```
 

--- a/040-SDK/103-update.mdx
+++ b/040-SDK/103-update.mdx
@@ -59,7 +59,8 @@ user = xata.records().update("Users", "myid" {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "UPDATE \"Users\" SET email = 'newemail@example.com' WHERE id = 'myid' RETURNING *;"
+  "statement": "UPDATE \"Users\" SET email = $1 WHERE id = $2 RETURNING *;",
+  "params": ["newemail@example.com", "myid"]
 }
 ```
 
@@ -93,7 +94,8 @@ user = xata.records().upsert("Users", "myid" {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "INSERT INTO \"Users\" (id, name) VALUES ('rec_c8hnbch26un1nl0rthkg', 'susan') ON CONFLICT (id) DO UPDATE SET name = 'Keanu Reeves' RETURNING *;"
+  "statement": "INSERT INTO \"Users\" (id, name) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET name = $3 RETURNING *;",
+  "params": ["rec_c8hnbch26un1nl0rthkg", "susan", "Keanu Reeves"]
 }
 ```
 
@@ -137,7 +139,8 @@ user = xata.records().update("Users", "rec_c8hnbch26un1nl0rthkg" {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "UPDATE \"Users\" SET counter = counter + 1 WHERE id = 'rec_c8hnbch26un1nl0rthkg' RETURNING *;"
+  "statement": "UPDATE \"Users\" SET counter = counter + 1 WHERE id = $1 RETURNING *;",
+  "params": ["rec_c8hnbch26un1nl0rthkg"],
 }
 ```
 
@@ -173,7 +176,8 @@ user = xata.records().update("Users", "rec_c8hnbch26un1nl0rthkg" {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "UPDATE \"Users\" SET counter = counter + 10 WHERE id = 'rec_c8hnbch26un1nl0rthkg' RETURNING *;"
+  "statement": "UPDATE \"Users\" SET counter = counter + 10 WHERE id = $1 RETURNING *;",
+  "params": ["rec_c8hnbch26un1nl0rthkg"],
 }
 ```
 
@@ -209,7 +213,8 @@ user = xata.records().update("Users", "rec_c8hnbch26un1nl0rthkg" {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "UPDATE \"Users\" SET counter = counter / 2 WHERE id = 'rec_c8hnbch26un1nl0rthkg' RETURNING *;"
+  "statement": "UPDATE \"Users\" SET counter = counter / 2 WHERE id = $1 RETURNING *;",
+  "params": ["rec_c8hnbch26un1nl0rthkg"],
 }
 ```
 
@@ -331,7 +336,8 @@ user = xata.records().update(
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "UPDATE \"Users\" SET email = 'keanu@xata.io', name = 'Keanu Reeves' WHERE id = 'rec_c8hnbch26un1nl0rthkg' AND \"xata.version\" = 0 RETURNING *;"
+  "statement": "UPDATE \"Users\" SET email = $1, name = $2 WHERE id = $3 AND \"xata.version\" = $4 RETURNING *;",
+  "params": ["keanu@xata.io", "Keanu Reeves", "rec_c8hnbch26un1nl0rthkg", 0],
 }
 ```
 

--- a/040-SDK/104-delete.mdx
+++ b/040-SDK/104-delete.mdx
@@ -26,7 +26,8 @@ user = xata.records().delete("Users", "rec_cd8s3r8avc42pi67m13g")
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "DELETE FROM \"Users\" WHERE id = 'rec_cd8s3r8avc42pi67m13g';"
+  "statement": "DELETE FROM \"Users\" WHERE id = $1;",
+  "params": ["rec_cd8s3r8avc42pi67m13g"]
 }
 ```
 
@@ -69,7 +70,8 @@ users = xata.records().transaction({
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "DELETE FROM \"Users\" WHERE id IN ('rec_cd8s3r8avc42pi67m13g','rec_cgh9o1oncchhigq95n2g');"
+  "statement": "DELETE FROM \"Users\" WHERE id IN ($1,$2);",
+  "params": ["rec_cd8s3r8avc42pi67m13g", "rec_cgh9o1oncchhigq95n2g"]
 }
 ```
 

--- a/040-SDK/115-filtering.mdx
+++ b/040-SDK/115-filtering.mdx
@@ -60,7 +60,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name = 'Keanu Reeves' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name = $1 LIMIT 20;",
+  "params": ["Keanu Reeves"]
 }
 ```
 
@@ -102,7 +103,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name = 'Keanu Reeves' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name = $1 LIMIT 20;",
+  "params": ["Keanu Reeves"]
 }
 ```
 
@@ -144,7 +146,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name IN ('Keanu Reeves','Carrie-Anne Moss') LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name IN ($1,$2) LIMIT 20;",
+  "params": ["Keanu Reeves", "Carrie-Ann Moss"]
 }
 ```
 
@@ -186,7 +189,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name = 'Keanu Reeves' AND city = 'New York' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name = $1 AND city = $2 LIMIT 20;",
+  "params": ["Keanu Reeves", "New York"]
 }
 ```
 
@@ -232,7 +236,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name = 'Keanu Reeves' OR city = 'New York' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name = $1 OR city = $2 LIMIT 20;",
+  "params": ["Keanu Reeves", "New York"]
 }
 ```
 
@@ -272,7 +277,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name = 'Keanu Reeves' OR name = 'Carrie-Anne Moss' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name = $1 OR name = $2 LIMIT 20;",
+  "params": ["Keanu Reeves", "Carrie-Ann Moss"]
 }
 ```
 
@@ -429,7 +435,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE NOT name = 'Keanu Reeves' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE NOT name = $1 LIMIT 20;",
+  "params": ["Keanu Reeves"]
 }
 ```
 
@@ -487,7 +494,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE NOT (name = 'Keanu Reeves' OR name = 'Laurence Fishburne') LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE NOT (name = $1 OR name = $2) LIMIT 20;"
+  "params": ["Keanu Reeves", "Laurence Fishburne"]
 }
 ```
 
@@ -540,7 +548,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name NOT IN ('Keanu Reeves','Laurence Fishburne') LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name NOT IN ($1,$2) LIMIT 20;",
+  "params": ["Keanu Reeves", "Laurence Fishburn"]
 }
 ```
 
@@ -583,7 +592,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE NOT name = 'Keanu Reeves' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE NOT name = $1 LIMIT 20;",
+  "params": ["Keanu Reeves"]
 }
 ```
 
@@ -634,7 +644,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name LIKE '%Keanu%' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name LIKE '%$1%' LIMIT 20;",
+  "params": ["Keanu Reeves"]
 }
 ```
 
@@ -676,7 +687,8 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name ~ 'K.*an.? R.*' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name ~ $1 LIMIT 20;",
+  "params": ["K.*an.? R.*"]
 }
 ```
 
@@ -731,13 +743,15 @@ records = xata.data().query("Users", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name ~ '^Keanu' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name ~ $1 LIMIT 20;",
+  "params": ["^Keanu"]
 }
 
 // or
 
 {
-  "statement": "SELECT * FROM \"Users\" WHERE name ~ 'Reeves$' LIMIT 20;"
+  "statement": "SELECT * FROM \"Users\" WHERE name ~ $1 LIMIT 20;",
+  "params": ["Reeves$"]
 }
 ```
 
@@ -846,7 +860,8 @@ records = xata.data().query("Posts", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT * FROM \"Posts\" WHERE \"xata.createdAt\"::timestamptz < '2022-10-25T02:00:00.000Z' AND \"xata.createdAt\"::timestamptz >= '2022-10-25T01:00:00.000Z' LIMIT 20;"
+  "statement": "SELECT * FROM \"Posts\" WHERE \"xata.createdAt\"::timestamptz < $1 AND \"xata.createdAt\"::timestamptz >= $2 LIMIT 20;",
+  "params": ["2022-10-25T02:00:00.000Z", "2022-10-25T01:00:00.000Z"]
 }
 ```
 
@@ -1000,7 +1015,8 @@ records = xata.data().query("Posts", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-    "statement": "SELECT * FROM \"Posts\" WHERE cardinality(\"labels\") = (SELECT sum((label LIKE '%mat%') :: int) FROM unnest(labels) AS label);"
+    "statement": "SELECT * FROM \"Posts\" WHERE cardinality(\"labels\") = (SELECT sum((label LIKE '%$1%') :: int) FROM unnest(labels) AS label);"
+  "params": ["mat"]
 }
 ```
 

--- a/040-SDK/121-summarize.mdx
+++ b/040-SDK/121-summarize.mdx
@@ -62,7 +62,8 @@ records = xata.data().summarize("sales", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT product,AVG(sale_price) FROM \"sales\" WHERE product = 'basketball' GROUP BY product;"
+  "statement": "SELECT product,AVG(sale_price) FROM \"sales\" WHERE product = $1 GROUP BY product;",
+  "params": ["basketball"]
 }
 ```
 
@@ -551,7 +552,8 @@ records = xata.data().summarize("sales", {
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
 
 {
-  "statement": "SELECT product, AVG(sale_price) AS average_sale_price FROM \"sales\" WHERE product = 'basketball' GROUP BY product;",
+  "statement": "SELECT product, AVG(sale_price) AS average_sale_price FROM \"sales\" WHERE product = $1 GROUP BY product;",
+  "params": ["basketball"],
   "consistency": "eventual"
 }
 ```


### PR DESCRIPTION
## Summary

This PR changes the existing SQL examples
to use parameterized queries to submit
query parameters.

Hopefully, this helps users avoid SQL injection
errors if we provide secure examples.
