### PR TITLE
Update 150-file-attachments.mdx

### DIFF
--- a/040-SDK/150-file-attachments.mdx
+++ b/040-SDK/150-file-attachments.mdx
@@ -275,5 +275,3 @@ curl 'https://{workspace}.{region}.xata.sh/db/{db}:{branch}/tables/{table}/data/
 
 </TabbedCode>
 
-For scenarios like web applications, web sites, content sharing, Xata offers direct access URLs for the stored files.
-There are 3 levels of access available:


### PR DESCRIPTION
The page ends abruptly with an incomplete paragraph.

This seems to be a leftover section as that part has been moved to https://xata.io/docs/concepts/file-attachments.
