### PR TITLE
Add percentile aggregation to the docs

### DIFF
--- a/040-SDK/120-aggregate.mdx
+++ b/040-SDK/120-aggregate.mdx
@@ -771,4 +771,68 @@ results = xata.data().aggregate("titles", {
 }
 ```
 
+### Percentiles
+
+`percentiles` is a metric-aggregation that computes the percentiles of a numeric column. You can specify an array with the percentiles you want to compute. For example, you can request the median by asking for the 50th percentile (`[50]`), or you can request the 50th and 90th and 99.9th percentiles by asking for `[50, 90, 99.9]`.
+
+Example:
+
+<TabbedCode tabs={['TypeScript', 'Python', 'JSON']}>
+
+```ts
+const records = await xata.db.titles.aggregate({
+  latencyPercentiles: {
+    percentiles: {
+      column: 'latency',
+      percentiles: [50, 90, 99, 99.9]
+    }
+  }
+});
+```
+
+```python
+results = xata.data().aggregate("titles", {
+  "aggs": {
+    "latencyPercentiles": {
+      "sum": {
+        "column": "latency",
+        "percentiles": [50, 90, 99, 99.9]
+      }
+    }
+  }
+})
+```
+
+```json
+// POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/tables/{table}/aggregate
+{
+  "aggs": {
+    "latencyPercentiles": {
+      "percentiles": {
+        "column": "latency",
+        "percentiles": [50, 90, 99, 99.9]
+      }
+    }
+  }
+}
+```
 </TabbedCode>
+
+The answer will be an object with a `values` subobject that has the percentiles as keys, and the values as the percentile values.
+For example:
+
+```json
+{
+  "aggs": {
+    "latencyPercentiles": {
+      "values": {
+        "50.0": 30,
+        "90:0": 78,
+        "99.0": 120,
+        "99.9": 124
+      }
+    }
+  }
+}
+```
+


### PR DESCRIPTION
This adds docs for https://github.com/xataio/xata/pull/3099 which is merged and available in prod by now.

We need to double check that the SDK will work like this, cc @eemmiillyy.  I also included the response format in this docs, they might be useful when developing the SDK.

### Timing

**Release**:

- We should wait for the SDK to be available before merging this.
