### PR TITLE
Provide clarification about differences between pagination methods

### DIFF
--- a/040-SDK/101-get.mdx
+++ b/040-SDK/101-get.mdx
@@ -697,8 +697,8 @@ This section doesn't apply to the TypeScript SDK, because it is offering a highe
 
 Xata offers two types of pagination:
 
-- cursor-based, using `after` and `before` parameters
-- offset-based, using `offset` and `limit` parameters
+- cursor-based, using `after` and `before` parameters. It is optimal for building `next / prev` navigation patterns.
+- offset-based, using `offset` and `limit` parameters. It is optimal for building `1..2..10...19..20` navigation patterns.
 
 ### Cursor-based Pagination
 
@@ -825,7 +825,7 @@ You can continue like this until `"more"` is returned as `false`.
 
 ### Offset-based Pagination
 
-The offset-page pagination limit is 50,000 records. In most cases, you should use the cursor-based pagination.
+Offset-based pagination provides more flexibility and allows you to request a specific page (using `offset`) within a total amount of records given a specific page `size`. This flexibility comes at a performance cost since the amount of total records needs to be known. To prevent slow response times, Xata sets a safeguard limit of 50,0000 total records that can be pagination using the offset style.
 
 An example of offset based pagination:
 
@@ -867,7 +867,7 @@ page = xata.data().query("Users", {
 
 </TabbedCode>
 
-You can find more information about pagination in the [API reference](/docs/api-reference/db/db_branch_name/tables/table_name/query#pagination).
+You can find more information about pagination in the [API reference](/docs/api-reference/db/db_branch_name/tables/table_name/query#pagination). When trying to make a decision between cursor and pagination styles we recommend starting with offset-based pagination since it provides more flexibility. As your app grows or when raw performance is needed, switch to the cursor-based method.
 
 ## Next Steps
 

--- a/040-SDK/101-get.mdx
+++ b/040-SDK/101-get.mdx
@@ -825,7 +825,7 @@ You can continue like this until `"more"` is returned as `false`.
 
 ### Offset-based Pagination
 
-Offset-based pagination provides more flexibility and allows you to request a specific page (using `offset`) within a total amount of records given a specific page `size`. This flexibility comes at a performance cost since the amount of total records needs to be known. To prevent slow response times, Xata sets a safeguard limit of 50,0000 total records that can be pagination using the offset style.
+Offset-based pagination provides more flexibility and allows you to request a specific page (using `offset`) within a total amount of records given a specific page `size`. This flexibility comes at a performance cost since the amount of total records needs to be known. To prevent slow response times, Xata sets a safeguard limit of 50,0000 total records that can be paginated using the offset style.
 
 An example of offset based pagination:
 


### PR DESCRIPTION
This adds some context on the differences between our two pagination methods and gives recommendations for when a user might use one or the other. We felt this was needed based on some conversations on Discord where users were using cursor based pagination when the offset pattern provided more flexibility.