### PR TITLE
add SDK limitation section with type recursion

### DIFF
--- a/040-SDK/010-TypeScript/010-overview.mdx
+++ b/040-SDK/010-TypeScript/010-overview.mdx
@@ -104,6 +104,6 @@ export const MyComponent: FC<MyComponentProps> = ({ records }) => {
 
 ## Limitations
 
-Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the language server.
+Type recursion is limited to 3 levels in the TypeScript SDK. This is to prevent excessive strain on both the type checker and the language server since each nested level adds computational complexity.
 
-Calls on deeper nested columns will still work, but you may notice a TypeScript error that the type cannot be inferred.
+Calls on deeper nested columns will still work, but a TypeScript error may be displayed indicating the type cannot to determined.

--- a/040-SDK/010-TypeScript/010-overview.mdx
+++ b/040-SDK/010-TypeScript/010-overview.mdx
@@ -104,6 +104,6 @@ export const MyComponent: FC<MyComponentProps> = ({ records }) => {
 
 ## Limitations
 
-Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the LSP.
+Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the Language Server Protocol (LSP).
 
 Calls on deeper nested columns will still work, but you may notice a TypeScript error that the type cannot be inferred.

--- a/040-SDK/010-TypeScript/010-overview.mdx
+++ b/040-SDK/010-TypeScript/010-overview.mdx
@@ -104,6 +104,6 @@ export const MyComponent: FC<MyComponentProps> = ({ records }) => {
 
 ## Limitations
 
-Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the Language Server Protocol (LSP).
+Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the language server.
 
 Calls on deeper nested columns will still work, but you may notice a TypeScript error that the type cannot be inferred.

--- a/040-SDK/010-TypeScript/010-overview.mdx
+++ b/040-SDK/010-TypeScript/010-overview.mdx
@@ -106,4 +106,4 @@ export const MyComponent: FC<MyComponentProps> = ({ records }) => {
 
 Type recursion is limited to 3 levels in the TypeScript SDK. This is to prevent excessive strain on both the type checker and the language server since each nested level adds computational complexity.
 
-Calls on deeper nested columns will still work, but a TypeScript error may be displayed indicating the type cannot to determined.
+Calls on deeper nested columns will still work, but a TypeScript error may be displayed indicating the type cannot be determined.

--- a/040-SDK/010-TypeScript/010-overview.mdx
+++ b/040-SDK/010-TypeScript/010-overview.mdx
@@ -101,3 +101,9 @@ export const MyComponent: FC<MyComponentProps> = ({ records }) => {
   );
 };
 ```
+
+## Limitations
+
+Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the LSP.
+
+Calls on deeper nested columns deeper will still work, but you may notice a TypeScript error that the type cannot be inferred.

--- a/040-SDK/010-TypeScript/010-overview.mdx
+++ b/040-SDK/010-TypeScript/010-overview.mdx
@@ -106,4 +106,4 @@ export const MyComponent: FC<MyComponentProps> = ({ records }) => {
 
 Type recursion is limited to 3 levels in the TypeScript SDK, because each nested level adds computational complexity to the type checker and the LSP.
 
-Calls on deeper nested columns deeper will still work, but you may notice a TypeScript error that the type cannot be inferred.
+Calls on deeper nested columns will still work, but you may notice a TypeScript error that the type cannot be inferred.


### PR DESCRIPTION
Document known limitation about type recursion from https://github.com/xataio/client-ts/issues/1221
