### PR TITLE
Fix a broken link to data-model page.

### DIFF
--- a/030-Concepts/075-file-attachments.mdx
+++ b/030-Concepts/075-file-attachments.mdx
@@ -24,7 +24,7 @@ To support file attachments, Xata provides two column types:
   - As the column may store an arbitrary number of files, this content cannot be used in query filters or in summary queries.
   - Files stored in this array column type carry a file id so they can be referenced in endpoints such as the binary File API.
 
-A full breakdown of the `file` and `file[]` column types can be found on the [data model](/docs/data-model#file) page.
+A full breakdown of the `file` and `file[]` column types can be found on the [data model](/docs/concepts/data-model#file) page.
 
 ## Content delivery network (CDN)
 


### PR DESCRIPTION
Closes #

## Summary

<!-- Add a brief description of changes -->
The [link](https://xata.io/docs/concepts/file-attachments#:~:text=A%20full%20breakdown,data%20model%20page.) to the data model page from the [File Attachment](https://xata.io/docs/concepts/file-attachments) page is broken and takes to the `/docs/data-model` route instead of `/docs/concepts/data-model` route, leading to a 404 error.

The PR fixes this tiny error.


---


### Timing

**Release**:

- [X] When ready