### PR TITLE
Fix pricing docs URL

### DIFF
--- a/060-Rest-API/040-limits.mdx
+++ b/060-Rest-API/040-limits.mdx
@@ -86,7 +86,7 @@ The REST API may return HTTP response code `429` as a throttling error when the 
 - **Request rate limit**: Total number of atomic HTTP requests submitted per second to any API endpoint under a branch
 - **Concurrency limit**: Number of requests executing in parallel at any given moment within a certain Store of a branch
 
-For more information on rate limits, see our [docs](/docs/pricing) or visit the [pricing page](/pricing)
+For more information on rate limits, see our [docs](/docs/concepts/pricing) or visit the [pricing page](/pricing)
 
 ## Store types
 


### PR DESCRIPTION
rate limiting URL was pointing to an old docs page.


### Timing

**Release**:

- [x] When ready
- [ ] Hold for release | Release after: <mm/dd/yy>
