### PR TITLE
clarify Postman Bearer Token

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,8 +32,8 @@ jobs:
             package.json
             pnpm-lock.yaml
             apps/website
-            configs/*
-            packages/*
+            configs
+            packages
           ref: ${{ inputs.branch || 'main' }}
           token: ${{ secrets.GIT_TOKEN }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,11 +25,15 @@ jobs:
 
     steps:
       - name: Checkout website repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: xataio/frontend-next
           sparse-checkout: |
+            package.json
+            pnpm-lock.yaml
             apps/website
+            configs/*
+            packages/*
           ref: ${{ inputs.branch || 'main' }}
           token: ${{ secrets.GIT_TOKEN }}
 

--- a/060-Rest-API/020-contexts.mdx
+++ b/060-Rest-API/020-contexts.mdx
@@ -68,6 +68,8 @@ The following are tools for API development and management. Insomnia serves as a
 
 ![Xata API in Postman](images/postman.png)
 
+Hint: In order to authenticate using Postman, select the Authorization type `Bearer Token` and place your Xata API Key in the Token section.
+
 ### OpenAPI Codegen
 
 With [OpenAPI Codegen](https://github.com/fabien0102/openapi-codegen) you can generate TypeScript fetcher functions or typed react-query hooks from your OpenAPI schema.

--- a/060-Rest-API/020-contexts.mdx
+++ b/060-Rest-API/020-contexts.mdx
@@ -68,7 +68,7 @@ The following are tools for API development and management. Insomnia serves as a
 
 ![Xata API in Postman](images/postman.png)
 
-Hint: In order to authenticate using Postman, select the Authorization type `Bearer Token` and place your Xata API Key in the Token section.
+> To authenticate using Postman, select the authorization type `Bearer Token` and place your Xata API key in the _Token_ section.
 
 ### OpenAPI Codegen
 

--- a/060-Rest-API/020-contexts.mdx
+++ b/060-Rest-API/020-contexts.mdx
@@ -68,7 +68,7 @@ The following are tools for API development and management. Insomnia serves as a
 
 ![Xata API in Postman](images/postman.png)
 
-> To authenticate using Postman, select the authorization type `Bearer Token` and place your Xata API key in the _Token_ section.
+> To authenticate using Postman, select the authorization type `Bearer Token` and paste your Xata API key in the _Token_ section.
 
 ### OpenAPI Codegen
 


### PR DESCRIPTION
Add a hint for configuring Postman authentication with Bearer Token.

This is not clear by default, so users tend to select the API Key method in Postman instead which does not prepend "Bearer" before the Xata API Key, resulting in auth error.