### PR TITLE
clarify retrieving base64Content

### DIFF
--- a/040-SDK/150-file-attachments.mdx
+++ b/040-SDK/150-file-attachments.mdx
@@ -166,6 +166,8 @@ record = xata.records().update("Users", "record_id", {
 
 ### Download a file through reading a record
 
+The `base64Content` must be requested explicitly, it is not returned when selecting columns using wildcard.
+
 <TabbedCode tabs={['TypeScript', 'Python', 'CURL']}>
 ```ts
 const user = await xata.db.Users.read('record_id', ['photo.name', 'photo.base64Content']);


### PR DESCRIPTION
This has come up a few times so needs to be clarified in docs: users are concerned when they don't get the file content when expanding with wildcard (`filecolumn.*`)

This clarifies the `base64Content` is not returned when selecting columns with wildcard and it needs to be called explicitly.