### PR TITLE
Document public file columns in schema

### DIFF
--- a/030-Concepts/050-schema.mdx
+++ b/030-Concepts/050-schema.mdx
@@ -36,9 +36,16 @@ Let's look at a JSON representation of a sample Xata schema to understand how it
           }
         },
         {
-          "name": "image",
+          "name": "avatar",
           "type": "file",
           "file": {
+            "defaultPublicAccess": true
+          }
+        },
+        {
+          "name": "photos",
+          "type": "file[]",
+          "file[]": {
             "defaultPublicAccess": true
           }
         }

--- a/030-Concepts/050-schema.mdx
+++ b/030-Concepts/050-schema.mdx
@@ -34,6 +34,13 @@ Let's look at a JSON representation of a sample Xata schema to understand how it
           "link": {
             "table": "users"
           }
+        },
+        {
+          "name": "image",
+          "type": "file",
+          "file": {
+            "defaultPublicAccess": true
+          }
         }
       ]
     },
@@ -79,6 +86,7 @@ These fields are **optional**:
 - `unique`: A boolean value answering the question "is every value in this column expected to be unique?"
 - `notNull`: A boolean value answering the question "is this column exected to have data?"
 - `defaultValue`: The default value of the column, if nothing is provided.
+- `file`: Specific to [file attachments](/docs/concepts/file-attachments), the `file` field will allow you to provide the `defaultPublicAccess` of files added to that record.
 
 ## Loading the Schema from a File
 

--- a/030-Concepts/075-file-attachments.mdx
+++ b/030-Concepts/075-file-attachments.mdx
@@ -118,6 +118,8 @@ img = xata.files().transform("https://us-east-1.storage.xata.sh/4u1fh2o6p10blbut
 
 </TabbedCode>
 
+Within the Xata UI you can make files public by default for the column by setting `Make files public by default` when creating the column. This can also be done programtically by setting a parameter on the file column in the [schema](/docs/concepts/schema).
+
 ![Entire columns can be made public by default](images/column-access-public.png)
 
 <Alert status="warning">

--- a/080-Recipes/020-create-schema-from-code.mdx
+++ b/080-Recipes/020-create-schema-from-code.mdx
@@ -68,6 +68,13 @@ xata init --schema /path/to/json_file.json
           "type": "string"
         },
         {
+          "name": "image",
+          "type": "file",
+          "file": {
+            "defaultPublicAccess": true
+          }
+        },
+        {
           "name": "team",
           "type": "link",
           "link": {

--- a/080-Recipes/020-create-schema-from-code.mdx
+++ b/080-Recipes/020-create-schema-from-code.mdx
@@ -68,9 +68,16 @@ xata init --schema /path/to/json_file.json
           "type": "string"
         },
         {
-          "name": "image",
+          "name": "avatar",
           "type": "file",
           "file": {
+            "defaultPublicAccess": true
+          }
+        },
+        {
+          "name": "photos",
+          "type": "file[]",
+          "file[]": {
             "defaultPublicAccess": true
           }
         },


### PR DESCRIPTION
Provides examples that show how to make file columns public by default. Related to https://github.com/xataio/client-ts/pull/1281