### PR TITLE
Clarify selecting base64Content and signedUrl

### DIFF
--- a/040-SDK/150-file-attachments.mdx
+++ b/040-SDK/150-file-attachments.mdx
@@ -282,7 +282,7 @@ photos = xata.data().query("Users", {
 
 </TabbedCode>
 
-The `base64Content` and ` signedUrl` will only be returned when requested explicitly. They are not included by default when requesting all metadata using wildcard.
+The `base64Content` and ` signedUrl` will only be returned when requested explicitly. They are not included by default when requesting all fields using wildcard.
 
 <TabbedCode tabs={['TypeScript', 'Python', 'JSON']}>
 ```ts

--- a/040-SDK/150-file-attachments.mdx
+++ b/040-SDK/150-file-attachments.mdx
@@ -300,7 +300,7 @@ photos = xata.data().query("Users", {
 })
 ```
 
-````jsonc
+```jsonc
 // POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/tables/{table}/query
 
 {
@@ -308,6 +308,7 @@ photos = xata.data().query("Users", {
   "filter": { "photo.mediaType": "image/png" },
   "sort": { "photo.size": "desc" }
 }
+```
 
 </TabbedCode>
 

--- a/040-SDK/150-file-attachments.mdx
+++ b/040-SDK/150-file-attachments.mdx
@@ -325,7 +325,7 @@ Similar to the other Xata APIs, the file APIs require the Authorization header a
 <TabbedCode tabs={['TypeScript', 'Python', 'cURL']}>
 ```ts
 await xata.files.upload({ table: 'table_name', column: 'column_name', record: 'record_id' }, file);
-````
+```
 
 ```python
 response = xata.files().put("table_name", "record_id", "column_name", file_content)

--- a/040-SDK/150-file-attachments.mdx
+++ b/040-SDK/150-file-attachments.mdx
@@ -282,6 +282,35 @@ photos = xata.data().query("Users", {
 
 </TabbedCode>
 
+The `base64Content` and ` signedUrl` will only be returned when requested explicitly. They are not included by default when requesting all metadata using wildcard.
+
+<TabbedCode tabs={['TypeScript', 'Python', 'JSON']}>
+```ts
+const photos = await xata.db.Users.select(['name', 'photo.base64Content', 'photo.signedUrl', 'photo.*'])
+  .filter({ 'photo.mediaType': 'image/png' })
+  .sort('photo.size', 'desc')
+  .getMany();
+```
+
+```python
+photos = xata.data().query("Users", {
+  "columns": ["name", "photo.base64Content", "photo.signedUrl", "photo.*"],
+  "filter": { "photo.mediaType": "image/png" },
+  "sort": { "photo.size": "desc" }
+})
+```
+
+````jsonc
+// POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/tables/{table}/query
+
+{
+  "columns": ["name", "photo.base64Content", "photo.signedUrl", "photo.*"],
+  "filter": { "photo.mediaType": "image/png" },
+  "sort": { "photo.size": "desc" }
+}
+
+</TabbedCode>
+
 ## File (binary) APIs
 
 Since all record APIs use JSON for both request and response body, the file content needs to be encoded. For reasons like performance or data size on the wire, encoding the content might not be desired.
@@ -295,7 +324,7 @@ Similar to the other Xata APIs, the file APIs require the Authorization header a
 <TabbedCode tabs={['TypeScript', 'Python', 'cURL']}>
 ```ts
 await xata.files.upload({ table: 'table_name', column: 'column_name', record: 'record_id' }, file);
-```
+````
 
 ```python
 response = xata.files().put("table_name", "record_id", "column_name", file_content)


### PR DESCRIPTION
An additional reference for how to get file content and signed urls as users continue to step on this.