### PR TITLE
add powershell encapsulation note to all starters

### DIFF
--- a/020-Getting-started/030-Framework-starter-guides/010-astro.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/010-astro.mdx
@@ -32,6 +32,8 @@ Install the Xata CLI:
 npm install -g @xata.io/cli
 ```
 
+> If you are installing the Xata CLI on Windows using Powershell, you may need to wrap this part of the install command in quotes: `'@xata.io/cli'`
+
 Once installed, authenticate the Xata CLI with your Xata account. If you don't already have an account, you can use the
 same workflow to sign up for a new account. Run the following command to begin the authentication workflow:
 

--- a/020-Getting-started/030-Framework-starter-guides/020-nextjs.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/020-nextjs.mdx
@@ -32,6 +32,8 @@ Install the Xata CLI:
 npm install -g @xata.io/cli
 ```
 
+> If you are installing the Xata CLI on Windows using Powershell, you may need to wrap this part of the install command in quotes: `'@xata.io/cli'`
+
 Once installed, authenticate the Xata CLI with your Xata account. If you don't already have an account, you can use the
 same workflow to signup for a new account. Run the following command to begin the authentication workflow:
 

--- a/020-Getting-started/030-Framework-starter-guides/030-nuxt.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/030-nuxt.mdx
@@ -32,6 +32,8 @@ Install the Xata CLI:
 npm install -g @xata.io/cli
 ```
 
+> If you are installing the Xata CLI on Windows using Powershell, you may need to wrap this part of the install command in quotes: `'@xata.io/cli'`
+
 Once installed, authenticate the Xata CLI with your Xata account. If you don't already have an account, you can use the
 same workflow to sign up for a new account. Run the following command to begin the authentication workflow:
 

--- a/020-Getting-started/030-Framework-starter-guides/040-remix.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/040-remix.mdx
@@ -32,6 +32,8 @@ Install the Xata CLI:
 npm install -g @xata.io/cli
 ```
 
+> If you are installing the Xata CLI on Windows using Powershell, you may need to wrap this part of the install command in quotes: `'@xata.io/cli'`
+
 Once installed, authenticate the Xata CLI with your Xata account. If you don't already have an account, you can use the
 same workflow to sign up for a new account. Run the following command to begin the authentication workflow:
 

--- a/020-Getting-started/030-Framework-starter-guides/050-sveltekit.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/050-sveltekit.mdx
@@ -32,6 +32,8 @@ Install the Xata CLI:
 npm install -g @xata.io/cli
 ```
 
+> If you are installing the Xata CLI on Windows using Powershell, you may need to wrap this part of the install command in quotes: `'@xata.io/cli'`
+
 Once installed, authenticate the Xata CLI with your Xata account. If you don't already have an account, you can use the
 same workflow to sign up for a new account. Run the following command to begin the authentication workflow:
 

--- a/020-Getting-started/030-Framework-starter-guides/060-solidstart.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/060-solidstart.mdx
@@ -32,6 +32,8 @@ Install the Xata CLI:
 npm install -g @xata.io/cli
 ```
 
+> If you are installing the Xata CLI on Windows using Powershell, you may need to wrap this part of the install command in quotes: `'@xata.io/cli'`
+
 Once installed, authenticate the Xata CLI with your Xata account. If you don't already have an account, you can use the
 same workflow to sign up for a new account. Run the following command to begin the authentication workflow:
 


### PR DESCRIPTION
Adds the same note as in the [CLI Install page ](https://xata.io/docs/getting-started/cli#installation) to all framework starter guides as Windows users have stepped on this while working with the starters.