### PR TITLE
add sorting nested json example

### DIFF
--- a/040-SDK/101-get.mdx
+++ b/040-SDK/101-get.mdx
@@ -983,7 +983,7 @@ users = xata.data().query("Users", {
 
 Note that random sorting does not apply to a specific column, hence the special column name `"*"`.
 
-It is possible to sort on nested JSON fields with SQL using the `->` operator and quoting the json key.
+You can sort nested JSON fields in SQL by using the `->` operator and enclosing the JSON key in quotes.
 
 <TabbedCode tabs={['TypeScript','Python','SQL']}>
 

--- a/040-SDK/101-get.mdx
+++ b/040-SDK/101-get.mdx
@@ -983,6 +983,28 @@ users = xata.data().query("Users", {
 
 Note that random sorting does not apply to a specific column, hence the special column name `"*"`.
 
+It is possible to sort on nested JSON fields with SQL using the `->` operator and quoting the json key.
+
+<TabbedCode tabs={['TypeScript','Python','SQL']}>
+
+```ts
+const { users } = await xata.sql<UsersRecord>`SELECT * FROM \"Users\" ORDER BY properties->'address' DESC LIMIT 20`;
+```
+
+```python
+records = xata.sql().query("SELECT * FROM \"Users\" ORDER BY properties->'address' DESC LIMIT 20;")
+```
+
+```jsonc
+// POST https://{workspace}.{region}.xata.sh/db/{db}:{branch}/sql
+
+{
+  "statement": "SELECT * FROM \"Users\" ORDER BY properties->'address' DESC LIMIT 20;"
+}
+```
+
+</TabbedCode>
+
 ## Paginating Results
 
 This section doesn't apply to the TypeScript SDK, because it is offering a higher-level abstraction over the pagination mechanism. See the

--- a/040-SDK/101-get.mdx
+++ b/040-SDK/101-get.mdx
@@ -1005,7 +1005,7 @@ records = xata.sql().query("SELECT * FROM \"Users\" ORDER BY properties->'addres
 
 </TabbedCode>
 
-## Paginating Results
+## Paginating results
 
 This section doesn't apply to the TypeScript SDK, because it is offering a higher-level abstraction over the pagination mechanism. See the
 [query functions](/docs/sdk/get#the-typescript-sdk-functions-for-querying) section. Only REST API examples are provided in this section.


### PR DESCRIPTION
Adds a reference for sorting by nested json keys. This is currently not possible in the REST API but is supported with the SQL proxy.