### PR TITLE
Workflow remove reference to starters

### DIFF
--- a/020-Getting-started/040-workflow.mdx
+++ b/020-Getting-started/040-workflow.mdx
@@ -9,8 +9,6 @@ published: true
 
 This guide introduces the core Xata workflow and outlines the process of configuring a project for branching and migrations using GitHub in conjunction with Netlify or Vercel. After completing the configuration, pull requests created in GitHub will generate Xata database previews that link to preview deployments in either Vercel or Netlify. After merging the pull requests, Xata will perform database migrations in sync with your code, resulting in the deployment of changes to production.
 
-The following tutorial leverages [our starter example database](/docs/examples/starters-samples), but the methods used can be applied to any Xata database.
-
 ## Prerequisites
 
 This guide assumes:


### PR DESCRIPTION
This was brought up by a community member.
Removing an extraneous reference: the workflow guide does not really rely a starter example. The link is also broken since we removed the starters.