### PR TITLE
Fix Go SDK (follow up from #217)

### DIFF
--- a/020-Getting-started/020-installation.mdx
+++ b/020-Getting-started/020-installation.mdx
@@ -95,7 +95,7 @@ import (
 )
 func main() {
 	// Environment variables, like `XATA_API_KEY`, are detected from the client
-	client := xata.NewClient()
+	workspaces, _ := xata.NewWorkspacesClient()
 }
 ```
 </TabbedCode>


### PR DESCRIPTION
PR https://github.com/xataio/mdx-docs/pull/217 introduced an incorrect way to initialize the Go SDK.