### PR TITLE
Python snippet transaction trailing s

### DIFF
--- a/040-SDK/130-transaction.mdx
+++ b/040-SDK/130-transaction.mdx
@@ -271,7 +271,7 @@ const result = await xata.transactions.run([
 ```
 
 ```python
-result = xata.records().transactions({
+result = xata.records().transaction({
   "operations": [
     {
       "update": {


### PR DESCRIPTION
Another instance of `xata.records().transactions` instead of `transaction`.