### PR TITLE
chore: consolidate example workspace id

### DIFF
--- a/020-Getting-started/030-Framework-starter-guides/010-astro.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/010-astro.mdx
@@ -136,7 +136,7 @@ xata init
 $ xata init
 🦋 Initializing project... We will ask you some questions.
 
-You have a single workspace, using it by default: xata-workspace-hc84d7
+You have a single workspace, using it by default: my-workspace-123456
 ✔ Select a database or create a new one › <Create a new database>
 ✔ New database name … xata-astro
 ✔ Select a region › eu-west-1
@@ -165,7 +165,7 @@ Generated Xata code to ./src/xata.ts
 
 ✔ Project setup with Xata 🦋
 
-i Setup tables and columns at https://app.xata.io/workspaces/xata-workspace-hc84d7/dbs/xata-astro:eu-west-1
+i Setup tables and columns at https://app.xata.io/workspaces/my-workspace-123456/dbs/xata-astro:eu-west-1
 
 i Use xata pull main to regenerate code and types from your Xata database
 

--- a/020-Getting-started/030-Framework-starter-guides/020-nextjs.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/020-nextjs.mdx
@@ -133,7 +133,7 @@ xata init
 $ xata init
 🦋 Initializing project... We will ask you some questions.
 
-You have a single workspace, using it by default: your-workspace-hc84d7
+You have a single workspace, using it by default: my-workspace-123456
 ✔ Select a database or create a new one › <Create a new database>
 ✔ New database name … xata-nextjs
 ✔ Select a region › eu-west-1
@@ -165,7 +165,7 @@ Generated Xata code to ./src/xata.ts
 
 ✔ Project setup with Xata 🦋
 
-i Setup tables and columns at https://app.xata.io/workspaces/xata-workspace-hc84d7/dbs/xata-nextjs:eu-west-1
+i Setup tables and columns at https://app.xata.io/workspaces/my-workspace-123456/dbs/xata-nextjs:eu-west-1
 
 i Use xata pull main to regenerate code and types from your Xata database
 ```

--- a/020-Getting-started/030-Framework-starter-guides/030-nuxt.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/030-nuxt.mdx
@@ -103,7 +103,7 @@ xata init
 ```sh
 $ 🦋 Initializing project... We will ask you some questions.
 
-You have a single workspace, using it by default: xata-workspace-hc84d7
+You have a single workspace, using it by default: my-workspace-123456
 ✔ Select a database or create a new one › <Create a new database>
 ✔ New database name … xata-nuxt
 ✔ Select a region › eu-west-1
@@ -135,7 +135,7 @@ Generated Xata code to ./src/xata.ts
 
 ✔ Project setup with Xata 🦋
 
-i Setup tables and columns at https://app.xata.io/workspaces/xata-workspace-hc84d7/dbs/xata-nuxt:eu-west-1
+i Setup tables and columns at https://app.xata.io/workspaces/my-workspace-123456/dbs/xata-nuxt:eu-west-1
 
 i Use xata pull main to regenerate code and types from your Xata database
 ```

--- a/020-Getting-started/030-Framework-starter-guides/040-remix.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/040-remix.mdx
@@ -111,7 +111,7 @@ xata init
 xata init
 🦋 Initializing project... We will ask you some questions.
 
-You have a single workspace, using it by default: Phil-Leggetter-s-workspace-hc84d7
+You have a single workspace, using it by default: my-workspace-123456
 ✔ Select a database or create a new one › <Create a new database>
 ✔ New database name … xata-remix
 ✔ Select a region › eu-west-1
@@ -143,7 +143,7 @@ Generated Xata code to ./src/xata.ts
 
 ✔ Project setup with Xata 🦋
 
-i Setup tables and columns at https://app.xata.io/workspaces/xata-workspace-hc84d7/dbs/xata-remix:eu-west-1
+i Setup tables and columns at https://app.xata.io/workspaces/my-workspace-123456/dbs/xata-remix:eu-west-1
 
 i Use xata pull main to regenerate code and types from your Xata database
 ```

--- a/020-Getting-started/030-Framework-starter-guides/050-sveltekit.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/050-sveltekit.mdx
@@ -104,7 +104,7 @@ xata init
 xata init
 🦋 Initializing project... We will ask you some questions.
 
-You have a single workspace, using it by default: xata-workspace-hc84d7
+You have a single workspace, using it by default: my-workspace-123456
 ✔ Select a database or create a new one › <Create a new database>
 ✔ New database name … xata-sveltekit
 ✔ Select a region › eu-west-1
@@ -141,7 +141,7 @@ Generated Xata code to ./src/xata.ts
 
 ✔ Project setup with Xata 🦋
 
-i Setup tables and columns at https://app.xata.io/workspaces/xata-hc84d7/dbs/xata-sveltekit:eu-west-1
+i Setup tables and columns at https://app.xata.io/workspaces/my-workspace-123456/dbs/xata-sveltekit:eu-west-1
 
 i Use xata pull main to regenerate code and types from your Xata database
 ```

--- a/020-Getting-started/030-Framework-starter-guides/060-solidstart.mdx
+++ b/020-Getting-started/030-Framework-starter-guides/060-solidstart.mdx
@@ -124,7 +124,7 @@ xata init
 xata init
 🦋 Initializing project... We will ask you some questions.
 
-You have a single workspace, using it by default: xata-workspace-hc84d7
+You have a single workspace, using it by default: my-workspace-123456
 ✔ Select a database or create a new one › <Create a new database>
 ✔ New database name … xata-solidstart
 ✔ Select a region › eu-west-1
@@ -156,7 +156,7 @@ Generated Xata code to ./src/xata.ts
 
 ✔ Project setup with Xata 🦋
 
-i Setup tables and columns at https://app.xata.io/workspaces/xata-workspace-hc84d7/dbs/xata-solidstart:eu-west-1
+i Setup tables and columns at https://app.xata.io/workspaces/my-workspace-123456/dbs/xata-solidstart:eu-west-1
 
 i Use xata pull main to regenerate code and types from your Xata database
 ```

--- a/060-Rest-API/020-contexts.mdx
+++ b/060-Rest-API/020-contexts.mdx
@@ -33,7 +33,7 @@ https://{workspace-display-name}-{workspace-id}.{region}.xata.sh/db/{dbname}
 An example of this is:
 
 ```text
-https://your-workspace-71fpth.us-east-1.xata.sh/db/yourdatabase
+https://my-workspace-123456.us-east-1.xata.sh/db/yourdatabase
 ```
 
 In the above:

--- a/080-Recipes/010-CSV-data/020-import-csv-data-CLI.mdx
+++ b/080-Recipes/010-CSV-data/020-import-csv-data-CLI.mdx
@@ -36,7 +36,7 @@ The interactive menu will allow you to select the Workspace, database, and branc
 
 ```shell
 ? Select a workspace ›
-❯   my_workspace - my_workspace-q5tboj
+❯   my_workspace - my-workspace-123456
 
 ? Select a database ›
 ❯   my_database


### PR DESCRIPTION
## Summary
Updates existing references to workspace name and id to use a consistent example `my-workspace-123456`. We should strive to reuse this for any future examples of workspace name and id in the docs. 

---

### Timing

**Release**:

- [x] When ready
