### PR TITLE
document json limitations in search

### DIFF
--- a/030-Data-types/030-data-model.mdx
+++ b/030-Data-types/030-data-model.mdx
@@ -509,7 +509,7 @@ Example definition:
 <Alert status="warning">
   It is possible to filter by nested json fields, but *sorting* on nested json fields is not available with the Xata
   API. Refer to the [result sorting](/docs/sdk/get#sorting-the-results) documentation for an alternative approach with
-  SQL.
+  SQL. JSON columns are mapped as plain text in the Search store.
 </Alert>
 
 ## Special Columns

--- a/040-Data-operations/111-search.mdx
+++ b/040-Data-operations/111-search.mdx
@@ -517,8 +517,8 @@ results = xata.data().search_branch({
 
 Limitations:
 
-- It is not possible to filter by linked columns. In the Search store, columns of `link` type contain only the `id` of the linked record.
-- Columns of `json` type are mapped as plain text for Search. It is not possible to apply filters on specific nested nodes in a JSON object.
+- It is not possible to apply filters on linked columns. For Search, columns of `link` type contain only the `id` of the linked record.
+- It is not possible to apply filters on specific nested nodes in a JSON object. For Search, columns of `json` type are mapped as plain text.
 
 ## Target specific columns
 

--- a/040-Data-operations/111-search.mdx
+++ b/040-Data-operations/111-search.mdx
@@ -513,12 +513,12 @@ results = xata.data().search_branch({
 }
 ```
 
+</TabbedCode>
+
 Limitations:
 
 - It is not possible to filter by linked columns. In the Search store, columns of `link` type contain only the `id` of the linked record.
 - Columns of `json` type are mapped as plain text for Search. It is not possible to apply filters on specific nested nodes in a JSON object.
-
-</TabbedCode>
 
 ## Target specific columns
 

--- a/040-Data-operations/111-search.mdx
+++ b/040-Data-operations/111-search.mdx
@@ -465,7 +465,7 @@ The above will match records containing `Keanu`.
 
 ## Filter records before search is performed
 
-Filtering allows you to filter out records before passing them through the search algorithm. The filtering syntax is the same as for the query API, with the limitation that you cannot filter by linked columns.
+Filtering allows you to filter out records before passing them through the search algorithm. The filtering syntax is the same as for the query API.
 
 The filtering is applied at the table level. For example:
 
@@ -512,6 +512,11 @@ results = xata.data().search_branch({
   ]
 }
 ```
+
+Limitations:
+
+- It is not possible to filter by linked columns. In the Search store, columns of `link` type contain only the `id` of the linked record.
+- Columns of `json` type are mapped as plain text for Search. It is not possible to apply filters on specific nested nodes in a JSON object.
 
 </TabbedCode>
 


### PR DESCRIPTION
Document limitations due to JSON mapped as `text` in Search.