### PR TITLE
Add doc status schema and yaml

### DIFF
--- a/020-Connect/010-Postgres/010-sql-access.mdx
+++ b/020-Connect/010-Postgres/010-sql-access.mdx
@@ -4,6 +4,7 @@ description: How to access Xata using SQL directly
 keywords: ['sql', 'access', 'rest']
 slug: sdk/sql/overview
 published: true
+status: alpha
 ---
 
 Xata uses PostgreSQL under the hood to store your data. You can use SQL to work with your data. The results come back in a typical Xata JSON response mechanism over HTTP. If the Xata API doesn't cover the query you need, you can use SQL directly to do queries, insert data, update information, and delete records.

--- a/040-Data-operations/120-aggregate.mdx
+++ b/040-Data-operations/120-aggregate.mdx
@@ -5,12 +5,8 @@ keywords: ['aggregate', 'aggregations']
 description: Leverage the power of aggregations to perform calculations of records using the Xata SDK
 slug: sdk/aggregate
 published: true
+status: beta
 ---
-
-<Alert status="warning">
-  Aggregations are experimental. While we are currently avoiding breaking changes, we do not guarantee backwards
-  compatibility or that this endpoint will reach GA without major changes.
-</Alert>
 
 The `/aggregate` API allows you to use the search/analytics engine to perform aggregations on your data. Similar to the [search API](/docs/sdk/search),
 it is important to understand that the Aggregation API is served from a different store, which means: it is eventually consistent with the main store,

--- a/050-Manage/040-workflow.mdx
+++ b/050-Manage/040-workflow.mdx
@@ -5,6 +5,7 @@ keywords: ['Vercel', 'GitHub', 'branch', 'Netlify']
 description: Learn about core the Xata workflow, branching, and migrations using GitHub with Netlify or Vercel
 slug: getting-started/workflow
 published: true
+status: beta
 ---
 
 ## Migration file format

--- a/doc.schema.yaml
+++ b/doc.schema.yaml
@@ -27,6 +27,13 @@ properties:
   published:
     description: Whether to list this doc in the menu and search
     type: boolean
+  status:
+    description: state of the feature
+    type: string
+    enum:
+      - alpha
+      - beta
+      - production
 
 required:
   - title


### PR DESCRIPTION
Requires https://github.com/xataio/frontend-next/pull/3044 to merge first.

Adds status badges to documentation. Will not work in preview till the matching website PR merges.