### PR TITLE
Add missing database name reference

### DIFF
--- a/040-Data-operations/101-get.mdx
+++ b/040-Data-operations/101-get.mdx
@@ -46,7 +46,10 @@ data = xata.data().query("{table_name}", {
 ```go
 searchClient, _ := xata.NewSearchAndFilterClient()
 data, _ := searchClient.Query(context.TODO(), xata.QueryTableRequest{
-  TableName: "{tabel_name}",
+  BranchRequestOptional: xata.BranchRequestOptional{
+		DatabaseName: xata.String("{database_name}"),
+	},
+  TableName: "{table_name}",
   Payload: xata.QueryTableRequestPayload{
     Columns: []string{"col_1", ".."},
     Filter: &xata.FilterExpression{

--- a/040-Data-operations/101-get.mdx
+++ b/040-Data-operations/101-get.mdx
@@ -47,8 +47,8 @@ data = xata.data().query("{table_name}", {
 searchClient, _ := xata.NewSearchAndFilterClient()
 data, _ := searchClient.Query(context.TODO(), xata.QueryTableRequest{
   BranchRequestOptional: xata.BranchRequestOptional{
-		DatabaseName: xata.String("{database_name}"),
-	},
+	  DatabaseName: xata.String("{database_name}"),
+  },
   TableName: "{table_name}",
   Payload: xata.QueryTableRequestPayload{
     Columns: []string{"col_1", ".."},


### PR DESCRIPTION
Missing call out to show how to select a database in the xata-go SDK for the Query API.