### PR TITLE
Fix broken mp4 links

### DIFF
--- a/010-Getting-started/030-Framework-starter-guides/010-astro.mdx
+++ b/010-Getting-started/030-Framework-starter-guides/010-astro.mdx
@@ -18,7 +18,7 @@ Although this application is a simple blog, you can apply these basics to other 
 
 <ArticleVideo
   platform="html"
-  src="https://github.com/xataio/mdx-docs/raw/main/020-Getting-started/videos/getting-started-app.mp4"
+  src="https://github.com/xataio/mdx-docs/raw/main/010-Getting-started/videos/getting-started-app.mp4"
 />
 
 The completed [Astro and Xata code](https://github.com/xataio/examples/tree/main/apps/getting-started-astro) for this

--- a/010-Getting-started/030-Framework-starter-guides/020-nextjs.mdx
+++ b/010-Getting-started/030-Framework-starter-guides/020-nextjs.mdx
@@ -18,7 +18,7 @@ Although this application is a simple blog, you can apply these basics to other 
 
 <ArticleVideo
   platform="html"
-  src="https://github.com/xataio/mdx-docs/raw/main/020-Getting-started/videos/getting-started-app.mp4"
+  src="https://github.com/xataio/mdx-docs/raw/main/010-Getting-started/videos/getting-started-app.mp4"
 />
 
 The completed [Next.js and Xata code](https://github.com/xataio/examples/tree/main/apps/getting-started-nextjs) for this

--- a/010-Getting-started/030-Framework-starter-guides/030-nuxt.mdx
+++ b/010-Getting-started/030-Framework-starter-guides/030-nuxt.mdx
@@ -18,7 +18,7 @@ Although this application is a simple blog, you can apply these basics to other 
 
 <ArticleVideo
   platform="html"
-  src="https://github.com/xataio/mdx-docs/raw/main/020-Getting-started/videos/getting-started-app.mp4"
+  src="https://github.com/xataio/mdx-docs/raw/main/010-Getting-started/videos/getting-started-app.mp4"
 />
 
 The completed [Nuxt and Xata code](https://github.com/xataio/examples/tree/main/apps/getting-started-nuxt) for this

--- a/010-Getting-started/030-Framework-starter-guides/040-remix.mdx
+++ b/010-Getting-started/030-Framework-starter-guides/040-remix.mdx
@@ -18,7 +18,7 @@ Although this application is a simple blog, you can apply these basics to other 
 
 <ArticleVideo
   platform="html"
-  src="https://github.com/xataio/mdx-docs/raw/main/020-Getting-started/videos/getting-started-app.mp4"
+  src="https://github.com/xataio/mdx-docs/raw/main/010-Getting-started/videos/getting-started-app.mp4"
 />
 
 The completed [Remix and Xata code](https://github.com/xataio/examples/tree/main/apps/getting-started-remix) for this

--- a/010-Getting-started/030-Framework-starter-guides/050-sveltekit.mdx
+++ b/010-Getting-started/030-Framework-starter-guides/050-sveltekit.mdx
@@ -18,7 +18,7 @@ Although this application is a simple blog, you can apply these basics to other 
 
 <ArticleVideo
   platform="html"
-  src="https://github.com/xataio/mdx-docs/raw/main/020-Getting-started/videos/getting-started-app.mp4"
+  src="https://github.com/xataio/mdx-docs/raw/main/010-Getting-started/videos/getting-started-app.mp4"
 />
 
 The completed [SvelteKit and Xata code](https://github.com/xataio/examples/tree/main/apps/getting-started-sveltekit) for this

--- a/010-Getting-started/030-Framework-starter-guides/060-solidstart.mdx
+++ b/010-Getting-started/030-Framework-starter-guides/060-solidstart.mdx
@@ -18,7 +18,7 @@ Although this application is a simple blog, you can apply these basics to other 
 
 <ArticleVideo
   platform="html"
-  src="https://github.com/xataio/mdx-docs/raw/main/020-Getting-started/videos/getting-started-app.mp4"
+  src="https://github.com/xataio/mdx-docs/raw/main/010-Getting-started/videos/getting-started-app.mp4"
 />
 
 The completed [SolidStart and Xata code](https://github.com/xataio/examples/tree/main/apps/getting-started-solidstart) for this


### PR DESCRIPTION
Noticed the mp4 links were malformed on the GS pages. This was due to some folder name changes in the big reorg last week.

This is a small fix. I'll merge without review assuming green CI and a manual check of the build.