### PR TITLE
add reference for updating binary uploads with record API

### DIFF
--- a/040-Data-operations/150-file-attachments.mdx
+++ b/040-Data-operations/150-file-attachments.mdx
@@ -661,6 +661,8 @@ curl --request PUT 'https://{workspace}.{region}.xata.sh/db/{db}:{branch}/tables
 
 </TabbedCode>
 
+Use the [update record](/docs/sdk/file-attachments#update-a-file-through-updating-a-record) API to set file metadata such as `name` and `mediaType` for files uploaded using the binary file API.
+
 ### Download a file using file APIs
 
 `file` column type:


### PR DESCRIPTION
Clarifies setting metadata for files uploaded via binary API.