### PR TITLE
Simplify SQL examples

### DIFF
--- a/020-Connect/010-Postgres/010-sql-access.mdx
+++ b/020-Connect/010-Postgres/010-sql-access.mdx
@@ -148,13 +148,13 @@ Response:
 <TabbedCode tabs={['TypeScript', 'Python', 'JSON']}>
 ```ts
 const user = { name: "Keanu Reeves", email: "keanu@example.com" };
-const { records } = await xata.sql<UsersRecord>`INSERT INTO "Users" (name, email) VALUES (${user.name}, ${user.email})`;
+await xata.sql`INSERT INTO "Users" (name, email) VALUES (${user.name}, ${user.email})`;
 ```
 
 ```python
 name = "Keanu Reeves"
 email = "keanu@example.com"
-records = xata.sql().query(
+response = xata.sql().query(
   "INSERT INTO \"Users\" (name, email) VALUES ($1, $2)",
   [name, email]
 )
@@ -176,7 +176,7 @@ records = xata.sql().query(
 <TabbedCode tabs={['TypeScript', 'Python', 'JSON']}>
 ```ts
 const user = { id: "my-record-id" };
-await xata.sql<UsersRecord>`DELETE FROM "Users" WHERE id=${user.id}`;
+await xata.sql`DELETE FROM "Users" WHERE id=${user.id}`;
 ````
 
 ```python


### PR DESCRIPTION
## Summary

In TypeScript examples, when we don't expect a response, typing like this `xata.sql<UsersRecord>` was unnecessary, so I removed that to simplify. Also did a tiny change to the python example, because likewise we don't expect a list of records in the return.

