### PR TITLE
Alert component documentation and fixes for complicated markup

### DIFF
--- a/040-Data-operations/120-aggregate.mdx
+++ b/040-Data-operations/120-aggregate.mdx
@@ -217,7 +217,11 @@ There are two types of aggregations:
 - _bucket aggregations_, which split the data into buckets based on a column value. Examples of bucket aggregations are: `topValues`, `dateHistogram` and `numericHistogram`.
 - _metric aggregations_, which compute a value based on the data in the bucket. Examples of metric aggregations are: `average`, `sum`, `min`, `max`, `count` and `uniqueCount`.
 
-<Alert status="warning">Aggregations cannot be used with [link](/docs/concepts/data-model#link) columns.</Alert>
+<Alert status="warning">
+
+Aggregations cannot be used with [link](/docs/concepts/data-model#link) columns.
+
+</Alert>
 
 ## Response type
 

--- a/readme.md
+++ b/readme.md
@@ -41,12 +41,22 @@ The following are extra components that can be used within the markdown files.
 
 #### Alerts
 
-Alerts accept a `status` prop with values of `info | warning | danger`
+Alerts accept a `status` prop with values of `info | warning | danger`.
 
 ```tsx
 <Alert status="warning">
   This feature is Beta. It is still under active development. While we are avoiding breaking changes, we do not
   guarantee backwards compatibility until the functionality is GA.
+</Alert>
+```
+
+This component assumes your alert is simple and is a simple string (which is good practice). However, if you need multiple lines or other markdown (like links or images) you might need to include extra whitespace for proper rendering:
+
+```
+<Alert status="warning">
+
+Aggregations cannot be used with [link](/docs/concepts/data-model#link) columns.
+
 </Alert>
 ```
 


### PR DESCRIPTION
Fixes https://github.com/xataio/frontend-next/issues/3123

Added some documentation. The alert component typically assumes simple strings. You can get more verbose with some whitespace.

![image](https://github.com/xataio/mdx-docs/assets/324519/8b84dee5-a94c-4dff-8d33-64296f80b2c5)