### PR TITLE
Fix transaction delete code samples

### DIFF
--- a/040-Data-operations/130-transaction.mdx
+++ b/040-Data-operations/130-transaction.mdx
@@ -413,13 +413,13 @@ const result = await xata.transactions.run([
   {
     delete: {
       table: 'titles',
-      record: { id: 'rec_cfl4g6v00023' },
+      id: 'rec_cfl4g6v00023'
     }
   }, 
   {
     delete: {
       table: 'titles',
-      record: { id: 'rec_cfl4g6v00056' },
+      id: 'rec_cfl4g6v00056'
     }
   },
   // You can add additional operations
@@ -432,13 +432,13 @@ result = xata.records().transaction({
     {
       "delete": {
         "table": "titles",
-        "record": { "id": "rec_cfl4g6v00023" }
+        "id": "rec_cfl4g6v00023"
       }
     },
     {
       "delete": {
         "table": 'titles',
-        "record": { "id": "rec_cfl4g6v00056" },
+        "id": "rec_cfl4g6v00056"
       }
     },
     # You can add additional operations


### PR DESCRIPTION
I think there was some copy & pasting error because `record: {}` shouldn't be there. I tested the TypeScript one, but I suppose the Python should work the same. CC @philkra for a second pair of eyes.