### PR TITLE
add json to xata types table

### DIFF
--- a/030-Data-types/030-data-model.mdx
+++ b/030-Data-types/030-data-model.mdx
@@ -27,6 +27,7 @@ Below is a mapping of the additional data types Xata provides alongside Postgres
 | [filearray](#filearray) | xata.xata_file_array | json array stored natively as jsonb                     |
 | [link](#link)           | foreign key          |                                                         |
 | [vector](#vector)       | real[]               |                                                         |
+| [json](#json)           | jsonb                |                                                         |
 
 ## Limitations when using native Postgres types
 


### PR DESCRIPTION
The `json` column type was missing from the Xata types summary.