### PR TITLE
Add record size limitation to search docs

### DIFF
--- a/040-Data-operations/111-search.mdx
+++ b/040-Data-operations/111-search.mdx
@@ -1001,3 +1001,5 @@ The parameter definitions are:
 
 Default values added to existing records by creating new columns with default values, are not available in Search.
 These default values are available for new records and become accessible in existing records only in case of a subsequent record update.
+
+Individual records larger than 1MiB will not be available for search.


### PR DESCRIPTION
Add a note regarding search behaviour with records that are too large.

Relates to #4583