### PR TITLE
add ssl require option to postgres docs

### DIFF
--- a/020-Connect/010-Postgres/001-direct-access.mdx
+++ b/020-Connect/010-Postgres/001-direct-access.mdx
@@ -37,7 +37,7 @@ Typical Postgres parameters have Xata equivalents.
 With the mapping from above, the connection string to connect to our database `Games` on branch `main` is:
 
 ```txt
-postgresql://ws1234:xau_apikey123456@us-east-1.sql.xata.sh:5432/Games:main
+postgresql://ws1234:xau_apikey123456@us-east-1.sql.xata.sh:5432/Games:main?sslmode=require
 ```
 
 - The connection strings for HTTP access and Postgres wire protocol access are shown to you when you create a new database. You can view this connection string at any time by going to your database's settings page.
@@ -46,7 +46,7 @@ postgresql://ws1234:xau_apikey123456@us-east-1.sql.xata.sh:5432/Games:main
 Connect with [psql](https://www.postgresql.org/docs/current/app-psql.html) using the connection string format provided above:
 
 ```bash
-psql "postgresql://ws1234:xau_apikey123456@us-east-1.sql.xata.sh:5432/Games:main"
+psql "postgresql://ws1234:xau_apikey123456@us-east-1.sql.xata.sh:5432/Games:main?sslmode=require"
 
 Games:main=>
 ```
@@ -61,7 +61,7 @@ If you want control of the version, you should consider a [dedicated cluster](/d
 You can check the Postgres version with the following command:
 
 ```bash
-psql "postgresql://[Workspace Id]:[API key]@[Region].sql.xata.sh:[Port]/[Database]:[Branch]" -c "select version()"
+psql "postgresql://[Workspace Id]:[API key]@[Region].sql.xata.sh:[Port]/[Database]:[Branch]?sslmode=require" -c "select version()"
 ```
 
 ```sql
@@ -105,7 +105,7 @@ Use `psql` to import `.sql` files into a database branch.
 The following example imports the file `my_branch.sql` into the database `playground` on the branch `new_branch`.
 
 ```bash
-psql "postgresql://[Workspace Id]:[API key]@[Region].sql.xata.sh/playground:new_branch" < my_branch.sql
+psql "postgresql://[Workspace Id]:[API key]@[Region].sql.xata.sh/playground:new_branch?sslmode=require" < my_branch.sql
 ```
 
 The following limitations apply:


### PR DESCRIPTION
Adds sslmode require option in all examples, even if it's redundant for psql which defaults to it.

The connection string requires this option to work with other clients and ORMs (i.e. Drizzle) and it's hard for a user to notice the difference, so it's best to promote syntax that covers more uses.

From user feedback on [Discord](https://discord.com/channels/996791218879086662/996791219348852836/1245718350479233046).

