### PR TITLE
fix rev link sorting query

### DIFF
--- a/030-Data-types/030-data-model.mdx
+++ b/030-Data-types/030-data-model.mdx
@@ -584,7 +584,7 @@ const page = await xata.db.users
         "name",
         {
             name: "<-posts.author",
-            columns: ["title","createdAt"],
+            columns: ["title", "createdAt"],
             as: "posts",
             limit: 10,
             offset: 0,
@@ -626,7 +626,7 @@ users = self.client.data().query("Users", {
     "name",
     {
       "name": "<-posts.author",
-      "columns": ["title","createdAt"],
+      "columns": ["title", "createdAt"],
       "as": "posts",
       "limit": 10,
       "offset": 0,
@@ -643,7 +643,9 @@ users = self.client.data().query("Users", {
 
 </TabbedCode>
 
-Note that `createdAt` in the above sample is an additional, explicitly created, datetime column. The default columns `xata.createdAt`,`xata.updatedAt` and `xata.version` are not supported for reverse link sorting.
+Note that `createdAt` in the above sample is an additional, explicitly created, datetime column.
+The default columns `xata.createdAt`,`xata.updatedAt` and `xata.version` are not supported for reverse link sorting.
+In [Postgres enabled](https://xata.io/docs/postgres) databases, the corresponding internal columns can be used for reverse link sorting.
 
 The response would look like this (notice the nested `records` array under the `posts` field):
 

--- a/030-Data-types/030-data-model.mdx
+++ b/030-Data-types/030-data-model.mdx
@@ -584,7 +584,7 @@ const page = await xata.db.users
         "name",
         {
             name: "<-posts.author",
-            columns: ["title"],
+            columns: ["title","createdAt"],
             as: "posts",
             limit: 10,
             offset: 0,
@@ -604,7 +604,7 @@ const page = await xata.db.users
     "name",
     {
       "name": "<-posts.author",
-      "columns": ["title"],
+      "columns": ["title", "createdAt"],
       "as": "posts",
       "limit": 10,
       "offset": 0,
@@ -626,7 +626,7 @@ users = self.client.data().query("Users", {
     "name",
     {
       "name": "<-posts.author",
-      "columns": ["title"],
+      "columns": ["title","createdAt"],
       "as": "posts",
       "limit": 10,
       "offset": 0,
@@ -642,6 +642,8 @@ users = self.client.data().query("Users", {
 ```
 
 </TabbedCode>
+
+Note that `createdAt` in the above sample is an additional, explicitly created, datetime column. The default columns `xata.createdAt`,`xata.updatedAt` and `xata.version` are not supported for reverse link sorting.
 
 The response would look like this (notice the nested `records` array under the `posts` field):
 
@@ -663,6 +665,7 @@ The response would look like this (notice the nested `records` array under the `
           {
             "id": "rec_cie05srjtojbm41fv2t0",
             "title": "Introduction to Xata",
+            "createdAt": "2023-06-28T09:52:51.474094+00:00",
             "xata": {
               "createdAt": "2023-06-28T09:52:51.474094+00:00",
               "updatedAt": "2023-06-29T10:39:18.430212+00:00",
@@ -672,6 +675,7 @@ The response would look like this (notice the nested `records` array under the `
           {
             "id": "rec_cie05v3jtojbm41fv2tg",
             "title": "Working with relationships",
+            "createdAt": "2023-06-28T09:53:00.398131+00:00",
             "xata": {
               "createdAt": "2023-06-28T09:53:00.398131+00:00",
               "updatedAt": "2023-06-29T10:39:31.148422+00:00",
@@ -694,6 +698,7 @@ The response would look like this (notice the nested `records` array under the `
           {
             "id": "rec_cie060jjtojbm41fv2u0",
             "title": "Blue or Red?",
+            "createdAt": "2023-06-28T09:53:06.568533+00:00",
             "xata": {
               "createdAt": "2023-06-28T09:53:06.568533+00:00",
               "updatedAt": "2023-06-29T10:39:10.7602+00:00",


### PR DESCRIPTION
Because of the issue [5xx when column doesn't exist on query endpoint](https://github.com/xataio/xata/issues/3729), the docs example query doesn't work, as it is not selecting the createdAt column.

Also, due to [5xx from reverse link sorting on xata metadata](https://github.com/xataio/xata/issues/3738), adding a clarification that createdAt refers to another column, not the xata default one. Users often try to use the xata internal columns for sorting, which errors. These do work with pg databases though.