### PR TITLE
add workflow warnings for pg branches

### DIFF
--- a/050-Manage/040-pr-based-workflow.mdx
+++ b/050-Manage/040-pr-based-workflow.mdx
@@ -11,7 +11,8 @@ status: beta
 ## Migrations with GitHub
 
 <Alert status="warning">
-  **This feature is in beta**. We are currently rebuilding our migration strategy to incorporate
+  **This feature is in beta and is not yet compatible with databases that provide direct access to
+  [Postgres](https://xata.io/docs/postgres)**. We are currently rebuilding our migration strategy to incorporate
   [pgroll](https://github.com/xataio/pgroll) alongside native Postgres support. Until then, migrations and branching as
   documented below are limited in scope. The GitHub integration does not work within a monorepo with multiple Xata
   databases. File attachments within records will not get copied to generated preview branches. There is no rebase

--- a/050-Manage/040-pr-based-workflow.mdx
+++ b/050-Manage/040-pr-based-workflow.mdx
@@ -12,7 +12,7 @@ status: beta
 
 <Alert status="warning">
   **This feature is in beta and is not yet compatible with databases that provide direct access to
-  [Postgres](https://xata.io/docs/postgres)**. We are currently rebuilding our migration strategy to incorporate
+  [Postgres](/docs/postgres)**. We are currently rebuilding our migration strategy to incorporate
   [pgroll](https://github.com/xataio/pgroll) alongside native Postgres support. Until then, migrations and branching as
   documented below are limited in scope. The GitHub integration does not work within a monorepo with multiple Xata
   databases. File attachments within records will not get copied to generated preview branches. There is no rebase

--- a/070-Integrations/030-github.mdx
+++ b/070-Integrations/030-github.mdx
@@ -9,7 +9,7 @@ published: true
 
 <Alert status="warning">
   **This integration is not yet compatible with databases that provide direct access to
-  [Postgres](https://xata.io/docs/postgres)**.
+  [Postgres](/docs/postgres)**.
 </Alert>
 
 The Xata GitHub app promotes a collaborative Git-based workflow by managing all the necessary operations to keep your database in sync with your codebase. It also simplifies the creation of preview branches for all your pull requests.

--- a/070-Integrations/030-github.mdx
+++ b/070-Integrations/030-github.mdx
@@ -8,8 +8,7 @@ published: true
 ---
 
 <Alert status="warning">
-  **This integration is not yet compatible with databases that provide direct access to
-  [Postgres](/docs/postgres)**.
+  **This integration is not yet compatible with databases that provide direct access to [Postgres](/docs/postgres)**.
 </Alert>
 
 The Xata GitHub app promotes a collaborative Git-based workflow by managing all the necessary operations to keep your database in sync with your codebase. It also simplifies the creation of preview branches for all your pull requests.

--- a/070-Integrations/030-github.mdx
+++ b/070-Integrations/030-github.mdx
@@ -7,6 +7,11 @@ slug: integrations/github
 published: true
 ---
 
+<Alert status="warning">
+  **This integration is not yet compatible with databases that provide direct access to
+  [Postgres](https://xata.io/docs/postgres)**.
+</Alert>
+
 The Xata GitHub app promotes a collaborative Git-based workflow by managing all the necessary operations to keep your database in sync with your codebase. It also simplifies the creation of preview branches for all your pull requests.
 
 When you connect your application repo to your Xata database, Xata will take care of several steps for you. First, Xata will create a preview branch for all new pull requests. These preview branches contain a subset of the main (production) branch data, with up to 10,000 rows copied over from it. Additionally, any migrations present in the code will be executed to ensure that the branch follows the schema in the code.


### PR DESCRIPTION
Users of postgres-enabled databases have been trying to use the gh integration and workflow, which don't work while branch merging isn't possible with pg branches.