### PR TITLE
file name restrictions

### DIFF
--- a/040-Data-operations/150-file-attachments.mdx
+++ b/040-Data-operations/150-file-attachments.mdx
@@ -158,6 +158,8 @@ record, _ := recordsClient.Insert(context.TODO(), xata.InsertRecordRequest{
 }
 ```
 
+File names may consist of UTF-8 encoded ASCII excluding: control characters (`0x00-0x1F`,`0x7F` such as `\r`,`\n`,`\t`) and special characters `\",*,/,:,<,>,?,\\,|`.
+
 </TabbedCode>
 
 ### Update a file through updating a record


### PR DESCRIPTION
A user pointed out that the file name restrictions for file attachments are quite specific but not referenced in docs. This clarifies the valid character set for file names in the Records API.