### PR TITLE
Update the list of supported extensions on shared clusters

### DIFF
--- a/020-Connect/010-Postgres/001-direct-access.mdx
+++ b/020-Connect/010-Postgres/001-direct-access.mdx
@@ -73,10 +73,10 @@ PostgreSQL 15.4 on aarch64-unknown-linux-gnu, compiled by aarch64-unknown-linux-
 
 The default shared cluster setup ships with
 
-* [pgcrypto](https://www.postgresql.org/docs/current/pgcrypto.html)
-* [pgvector](https://github.com/pgvector/pgvector)
-* [plpgsql](https://www.postgresql.org/docs/current/plpgsql.html)
-* [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html)
+- [pgcrypto](https://www.postgresql.org/docs/current/pgcrypto.html)
+- [pgvector](https://github.com/pgvector/pgvector)
+- [plpgsql](https://www.postgresql.org/docs/current/plpgsql.html)
+- [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html)
 
 More extensions are available in [dedicated cluster](/docs/dedicated-cluster#Extensions) plans.
 

--- a/020-Connect/010-Postgres/001-direct-access.mdx
+++ b/020-Connect/010-Postgres/001-direct-access.mdx
@@ -71,7 +71,14 @@ PostgreSQL 15.4 on aarch64-unknown-linux-gnu, compiled by aarch64-unknown-linux-
 
 ## Extensions
 
-Extensions are only available in [dedicated cluster](/docs/dedicated-cluster#Extensions) plans. The default shared cluster setup ships with [plpgsql](https://www.postgresql.org/docs/current/plpgsql.html) only.
+The default shared cluster setup ships with
+
+* [pgcrypto](https://www.postgresql.org/docs/current/pgcrypto.html)
+* [pgvector](https://github.com/pgvector/pgvector)
+* [plpgsql](https://www.postgresql.org/docs/current/plpgsql.html)
+* [uuid-ossp](https://www.postgresql.org/docs/current/uuid-ossp.html)
+
+More extensions are available in [dedicated cluster](/docs/dedicated-cluster#Extensions) plans.
 
 ## Export
 


### PR DESCRIPTION
This PR adds `pgvector`, `pgcrypto` and `uuid-ossp` to the
list of supported extensions on shared clusters.
