### PR TITLE
Add note about default database branch in PostgreSQL connection string

### DIFF
--- a/020-Connect/010-Postgres/001-direct-access.mdx
+++ b/020-Connect/010-Postgres/001-direct-access.mdx
@@ -40,6 +40,7 @@ With the mapping from above, the connection string to connect to our database `G
 postgresql://ws1234:xau_apikey123456@us-east-1.sql.xata.sh:5432/Games:main?sslmode=require
 ```
 
+- The default branch is `main`. If you do not specify a branch name in the connection string, you connect to your `main` branch.
 - The connection strings for HTTP access and Postgres wire protocol access are shown to you when you create a new database. You can view this connection string at any time by going to your database's settings page.
 - API keys are stored at the user level and can be accessed within [account settings](https://app.xata.io/settings).
 


### PR DESCRIPTION
This PR adds a note about the default branch in the connection string.
If the user does not specify a branch name, we connect them to their
`main` branch.
