### PR TITLE
Add unsupported SQL statement

### DIFF
--- a/020-Connect/010-Postgres/001-direct-access.mdx
+++ b/020-Connect/010-Postgres/001-direct-access.mdx
@@ -227,6 +227,7 @@ The new Postgres abilities require breaking changes to some of our API layer. Wh
 The following statements and/or functions are not available for security reasons.
 
 - `SHOW password_encryption`
+- `SELECT pg_reload_conf()`
 - `SET ROLE`
 - `RESET ROLE`
 - `SET SESSION AUTHORIZATION`


### PR DESCRIPTION
`SELECT pg_reload_conf();` is not allowed