### PR TITLE
Drizzle: remove bullet point about foreign key limitations

### DIFF
--- a/020-Connect/020-JavaScript/030-drizzle.mdx
+++ b/020-Connect/020-JavaScript/030-drizzle.mdx
@@ -130,4 +130,3 @@ Currently, we recommend manually defining the schema like in the example above. 
 - Transactions are not supported in the HTTP client.
 - Drizzle Kit introspection has a bug with our xata_id default value. You need to manually wrap the value with backticks.
 - Xata [File attachments](/docs/sdk/file-attachments) columns are read-only and only shows file metadata. You will need to use the [SDK](/docs/sdk/typescript/overview) to upload and download files.
-- Foreign key references are not yet available as they depend on support for anonymous code blocks.


### PR DESCRIPTION
Has been fixed a while ago: https://github.com/xataio/xata/issues/4346