### PR TITLE
Docs - Fix Mislabelled Field

### DIFF
--- a/040-Data-operations/111-vector-search.mdx
+++ b/040-Data-operations/111-vector-search.mdx
@@ -118,7 +118,7 @@ results, _ := searchClient.VectorSearch(context.TODO(), xata.VectorSearchTableRe
 The results of a vector search query return a set of records from the specified table, that are most similar to the provided query vector. The response includes the following:
 
 - `totalCount`: The total number of records matching the query vector.
-- `records`: An array of the most relevant records. Each item in `records` includes the `id` and `score` within its `xata` column.
+- `records`: An array of the most relevant records. Each item in `records` includes the `id`, and `score` within its `xata` column.
 - `id`: A unique identifier for the record.
 - `score`: A similarity score (usually between 0 and 1) indicating how closely the record's vector matches the query vector.
 

--- a/040-Data-operations/111-vector-search.mdx
+++ b/040-Data-operations/111-vector-search.mdx
@@ -118,7 +118,7 @@ results, _ := searchClient.VectorSearch(context.TODO(), xata.VectorSearchTableRe
 The results of a vector search query return a set of records from the specified table, that are most similar to the provided query vector. The response includes the following:
 
 - `totalCount`: The total number of records matching the query vector.
-- `results`: An array of the most relevant records. Each item in `results` includes the `id` and `score`.
+- `records`: An array of the most relevant records. Each item in `records` includes the `id` and `score` within its `xata` column.
 - `id`: A unique identifier for the record.
 - `score`: A similarity score (usually between 0 and 1) indicating how closely the record's vector matches the query vector.
 


### PR DESCRIPTION
This PR corrects the mislabelled `results` field and adds context about the location of the `id` and `score` fields in the Vector Search docs.

### Issue
The docs describe the response from the `vectorSearch` function but it doesn't correspond to the actual response.

Here's the relevant section from the docs at https://xata.io/docs/sdk/vector-search:
> The response includes the following:
> 
> `totalCount`: The total number of records matching the query vector.
> `results`: An array of the most relevant records. Each item in `results` includes the `id` and `score`.
> `id`: A unique identifier for the record.
> `score`: A similarity score (usually between 0 and 1) indicating how closely the record's vector matches the query vector.

Here's an example of what is actually returned:
  ```js
  {
    records: [
      {
        embedding: [Array],
        id: 'rec_cqbn4h4kc6p3fbnr5hdg',
        contents: ‘Note example.’,
         "xata": {
                "createdAt": "2024-07-17T07:27:00.820Z",
                "score": 1.6335163,
                "table": "Notes",
                "updatedAt": "2024-07-17T07:27:00.820Z",
                "version": 0
            }
      }
    ],
    totalCount: 1
  }
  ```
 
