### PR TITLE
Fix typo and wording around the client.ts file

### DIFF
--- a/010-Getting-started/020-installation.mdx
+++ b/010-Getting-started/020-installation.mdx
@@ -110,7 +110,7 @@ For collaborative development in a common Workspace it is important to set up yo
 
 Committing these files to your project's repository, enables Workspace members to replicate your local setup by adding their own `XATA_API_KEY` to their `.env` file.
 
-To deploy your GitHub repository on hosting services like Vercel or Netlify, ensure you include the `src/client.ts` file from the Xata client in your repo. Not exposing your API key, ensures your Xata database is safe from DDoS attacks, even if the URL is visible. Remember, requests made without authentication won’t impact your Xata database's [rate limits](/docs/concepts/pricing#concurrency-limit). Exposing the `src/client.ts` file doesn't pose a risk to your database’s limits or security.
+To deploy your GitHub repository on hosting services like Vercel or Netlify, ensure you include the generated `src/xata.ts` file in your repo. Even if the repository is open source, exposing the `src/xata.ts` file generally doesn't pose a risk to your database’s limits or security, as long as the API key is a secret. The file does contain the database URL, but requests made without authentication won’t impact your Xata database's [rate limits](/docs/concepts/pricing#concurrency-limit).
 
 When creating templates or examples for public use and cloning, it is best to avoid committing files that have details specific to a database, like API endpoints and client configurations. Configuration files such as `src/xata.ts`,`.xatarc` and the `.xata` migrations folder are linked to a specific database.
 


### PR DESCRIPTION
Reported in Discord: https://discord.com/channels/996791218879086662/996791219348852836/1277769977893621901

The docs were discussing a `src/client.ts` file, likely meaning the `src/xata.ts` file. I also changed a bit the wording of the paragraph, I think it's easier to understand this way.