### PR TITLE
Remove postgis from shared cluster 001-direct-access.mdx

### DIFF
--- a/020-Connect/010-Postgres/001-direct-access.mdx
+++ b/020-Connect/010-Postgres/001-direct-access.mdx
@@ -77,7 +77,6 @@ The default shared cluster setup ships with
 - [pgvector](https://github.com/pgvector/pgvector/tree/v0.5.1)
 - [plpgsql](https://www.postgresql.org/docs/15/plpgsql.html)
 - [uuid-ossp](https://www.postgresql.org/docs/15/uuid-ossp.html)
-- [postgis](https://postgis.net/documentation/getting_started/)
 
 More extensions are available in [dedicated cluster](/docs/dedicated-cluster#extensions) plans.
 


### PR DESCRIPTION
Via support ticket https://support.xata.io/hc/en-us/requests/1433